### PR TITLE
Feat, Fix : 게시글과 관련없는 투표 항목에 투표 시 404 에러 처리 등

### DIFF
--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/AuthApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/AuthApiDocument.java
@@ -3,9 +3,12 @@ package teamkiim.koffeechat.domain.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.member.domain.Member;
+import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,7 +25,7 @@ public @interface AuthApiDocument {
      */
     @Operation(summary = "회원가입", description = "사용자가 회원가입 요청을 한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json",
                     examples = {@ExampleObject(name = "회원가입 요청한 이메일과 동일한 이메일이 이미 존재하는 경우",
                             value = "{\"code\": 409, \"message\": \"이미 회원가입된 이메일입니다.\"}")}
@@ -30,7 +33,8 @@ public @interface AuthApiDocument {
     })
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
-    @interface SignUpApiDoc {}
+    @interface SignUpApiDoc {
+    }
 
     /**
      * 로그인
@@ -49,7 +53,8 @@ public @interface AuthApiDocument {
     })
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
-    @interface loginApiDoc {}
+    @interface loginApiDoc {
+    }
 
     /**
      * 로그아웃
@@ -60,5 +65,6 @@ public @interface AuthApiDocument {
     })
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
-    @interface logoutApiDoc {}
+    @interface logoutApiDoc {
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/AuthController.java
@@ -1,16 +1,12 @@
 package teamkiim.koffeechat.domain.auth.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import teamkiim.koffeechat.domain.auth.controller.dto.LoginRequest;
 import teamkiim.koffeechat.domain.auth.controller.dto.SignUpRequest;
@@ -19,6 +15,7 @@ import teamkiim.koffeechat.domain.auth.service.AuthService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Validated
 @Tag(name = "인증 API")
 public class AuthController {
 

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/AuthController.java
@@ -51,5 +51,4 @@ public class AuthController {
         return authService.logout(request, response);
     }
 
-
 }

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/LoginRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/LoginRequest.java
@@ -14,7 +14,7 @@ import teamkiim.koffeechat.domain.auth.dto.request.LoginServiceRequest;
 @Schema(description = "Member 로그인 Request")
 public class LoginRequest {
 
-    @Schema(description = "로그인 이메일", example = "member@naver.com")
+    @Schema(description = "로그인 이메일", example = "koffeechat@naver.com")
     @NotBlank(message = "이메일을 입력해주세요")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
     private String email;

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/LoginRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/LoginRequest.java
@@ -11,13 +11,14 @@ import teamkiim.koffeechat.domain.auth.dto.request.LoginServiceRequest;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "Member 로그인 request")
+@Schema(description = "Member 로그인 Request")
 public class LoginRequest {
 
     @Schema(description = "로그인 이메일", example = "member@naver.com")
     @NotBlank(message = "이메일을 입력해주세요")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
     private String email;
+
     @Schema(description = "로그인 비밀번호", example = "1234asdf!@")
     @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/LoginRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/LoginRequest.java
@@ -1,6 +1,8 @@
 package teamkiim.koffeechat.domain.auth.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,10 +11,14 @@ import teamkiim.koffeechat.domain.auth.dto.request.LoginServiceRequest;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Member 로그인 request")
 public class LoginRequest {
 
+    @Schema(description = "로그인 이메일", example = "member@naver.com")
     @NotBlank(message = "이메일을 입력해주세요")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
     private String email;
+    @Schema(description = "로그인 비밀번호", example = "1234asdf!@")
     @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
 

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/SignUpRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/SignUpRequest.java
@@ -1,6 +1,8 @@
 package teamkiim.koffeechat.domain.auth.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,14 +12,20 @@ import teamkiim.koffeechat.domain.member.domain.MemberRole;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Member 회원가입 request")
 public class SignUpRequest {
 
+    @Schema(description = "회원가입용 이메일", example = "member@naver.com")
     @NotBlank(message = "이메일을 입력해주세요")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
     private String email;
+    @Schema(description = "회원가입용 비밀번호", example = "1234asdf!@")
     @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
+    @Schema(description = "회원가입용 닉네임", example = "커피챗")
     @NotBlank(message = "닉네임을 입력해주세요")
     private String nickname;
+    @Schema(description = "회원가입용 직업", defaultValue = "COMPANY_EMPLOYEE")
     private MemberRole memberRole;
 
     public SignUpServiceRequest toServiceRequest(){

--- a/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/SignUpRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/controller/dto/SignUpRequest.java
@@ -15,16 +15,20 @@ import teamkiim.koffeechat.domain.member.domain.MemberRole;
 @Schema(description = "Member 회원가입 request")
 public class SignUpRequest {
 
-    @Schema(description = "회원가입용 이메일", example = "member@naver.com")
+    @Schema(description = "회원가입용 이메일", example = "koffeechat@naver.com")
     @NotBlank(message = "이메일을 입력해주세요")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
     private String email;
+
     @Schema(description = "회원가입용 비밀번호", example = "1234asdf!@")
     @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
+
     @Schema(description = "회원가입용 닉네임", example = "커피챗")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣_.-]{3,10}$", message = "닉네임은 3~10자의 알파벳 대소문자, 숫자, _ . -만 사용 가능합니다.")
     @NotBlank(message = "닉네임을 입력해주세요")
     private String nickname;
+
     @Schema(description = "회원가입용 직업", defaultValue = "COMPANY_EMPLOYEE")
     private MemberRole memberRole;
 

--- a/src/main/java/teamkiim/koffeechat/domain/auth/service/AuthService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package teamkiim.koffeechat.domain.auth.service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -29,7 +31,7 @@ public class AuthService {
     /**
      * 회원가입
      * @param signUpServiceRequest 회원가입 요청 dto
-     * @return ok
+     * @return HttpStatus.CREATED
      */
     @Transactional
     public ResponseEntity<?> signUp(SignUpServiceRequest signUpServiceRequest){
@@ -44,7 +46,7 @@ public class AuthService {
 
         memberRepository.save(member);
 
-        return ResponseEntity.ok("회원가입이 완료되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /**

--- a/src/main/java/teamkiim/koffeechat/domain/comment/controller/CommentApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/comment/controller/CommentApiDocument.java
@@ -22,7 +22,7 @@ public @interface CommentApiDocument {
      */
     @Operation(summary = "댓글 저장", description = "사용자가 게시물에 댓글을 작성한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = ""),
+            @ApiResponse(responseCode = "201", description = "사용자가 작성한 댓글 저장 완료"),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
                     examples = {
                             @ExampleObject(name = "사용자를 찾을 수 없는 경우",
@@ -41,7 +41,7 @@ public @interface CommentApiDocument {
      */
     @Operation(summary = "댓글 수정", description = "사용자가 자신이 작성한 댓글을 수정한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = ""),
+            @ApiResponse(responseCode = "201", description = "사용자가 수정한 댓글 저장 완료"),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
                     examples = {
                             @ExampleObject(name = "해당 댓글을 찾을 수 없는 경우",
@@ -58,7 +58,7 @@ public @interface CommentApiDocument {
      */
     @Operation(summary = "댓글 삭제", description = "사용자가 자신이 작성한 댓글을 삭제한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = ""),
+            @ApiResponse(responseCode = "200", description = "사용자가 삭제한 댓글 삭제 완료"),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
                     examples = {
                             @ExampleObject(name = "해당 댓글을 찾을 수 없는 경우",

--- a/src/main/java/teamkiim/koffeechat/domain/comment/controller/CommentController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/comment/controller/CommentController.java
@@ -15,6 +15,7 @@ import teamkiim.koffeechat.domain.comment.controller.dto.CommentRequest;
 import teamkiim.koffeechat.domain.comment.controller.dto.ModifyCommentRequest;
 import teamkiim.koffeechat.domain.comment.service.CommentService;
 import teamkiim.koffeechat.global.Auth;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 import java.time.LocalDateTime;
 
@@ -29,9 +30,8 @@ public class CommentController {
     /**
      * 댓글 작성
      */
+    @AuthenticatedMemberPrincipal
     @PostMapping("/{postId}/comments")
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
     @CommentApiDocument.SaveCommentApiDoc
     public ResponseEntity<?> saveComment(@PathVariable("postId") Long postId,
                                          @Valid @RequestBody CommentRequest commentRequest, HttpServletRequest request){
@@ -46,9 +46,8 @@ public class CommentController {
     /**
      * 댓글 수정
      */
+    @AuthenticatedMemberPrincipal
     @PostMapping("/modify")
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
     @CommentApiDocument.ModifyCommentApiDoc
     public ResponseEntity<?> modifyComment(@Valid @RequestBody ModifyCommentRequest modifyCommentRequest){
 
@@ -60,9 +59,8 @@ public class CommentController {
     /**
      * 댓글 삭제
      */
+    @AuthenticatedMemberPrincipal
     @DeleteMapping("/delete/{commentId}")
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
     @CommentApiDocument.DeleteCommentApiDoc
     public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long commentId){
 

--- a/src/main/java/teamkiim/koffeechat/domain/comment/controller/dto/CommentRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/comment/controller/dto/CommentRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.comment.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,8 +12,10 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "댓글 저장 Request")
 public class CommentRequest {
 
+    @Schema(description = "댓글 내용", example = "댓글 내용입니다.")
     @NotBlank(message = "댓글을 작성해주세요.")
     String content;
 

--- a/src/main/java/teamkiim/koffeechat/domain/comment/controller/dto/ModifyCommentRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/comment/controller/dto/ModifyCommentRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.comment.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,10 +12,13 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "댓글 수정 Request")
 public class ModifyCommentRequest {
 
+    @Schema(description = "댓글 pk", example = "1")
     private Long id;
 
+    @Schema(description = "댓글 내용", example = "댓글 내용 수정입니다.")
     @NotBlank(message = "댓글을 작성해주세요.")
     private String content;
 

--- a/src/main/java/teamkiim/koffeechat/domain/comment/service/CommentService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/comment/service/CommentService.java
@@ -1,6 +1,8 @@
 package teamkiim.koffeechat.domain.comment.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +48,7 @@ public class CommentService {
 
         post.addComment(saveComment);               // 양방향 연관관계 주입
 
-        return ResponseEntity.ok("댓글 저장 완료");
+        return ResponseEntity.status(HttpStatus.CREATED).body("댓글 저장 완료");
     }
 
     /**
@@ -62,7 +64,7 @@ public class CommentService {
 
         comment.modify(modifyCommentServiceRequest.getContent(), modifyCommentServiceRequest.getCurrDateTime());
 
-        return ResponseEntity.ok("댓글 수정 완료");
+        return ResponseEntity.status(HttpStatus.CREATED).body("댓글 수정 완료");
     }
 
     /**

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminApiDocument.java
@@ -60,4 +60,56 @@ public @interface CorpAdminApiDocument {
     @Retention(RetentionPolicy.RUNTIME)
     @interface ManageCorpDomain {
     }
+
+    /**
+     * 도메인 삭제
+     */
+    @Operation(summary = "현직자 인증 도메인 삭제", description = "회사 도메인 관리, 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "도메인 삭제 완료"),
+            @ApiResponse(responseCode = "403", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "관리자 이외의 접근인 경우",
+                            value = "{\"code\": 403, \"message\": \"관리자만 접근이 가능합니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "회사 도메인 저장 정보를 찾을 수 없는 경우",
+                            value = "{\"code\": 404, \"message\": \"해당 회사 도메인 정보를 찾을 수 없습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface DeleteCorpDomain {
+    }
+
+    /**
+     * 도메인 목록 출력
+     */
+    @Operation(summary = "현직자 인증 도메인 리스트 확인", description = "등록되어있는 회사 도메인 리스트를 확인한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리스트 출력 완료"),
+            @ApiResponse(responseCode = "403", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "관리자 이외의 접근인 경우",
+                            value = "{\"code\": 403, \"message\": \"관리자만 접근이 가능합니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface List {
+    }
+
+    /**
+     * 도메인 키워드 기반 검색
+     */
+    @Operation(summary = "현직자 인증 도메인을 키워드 기반 검색한다.", description = "회사 이름, 도메인 기준 검색")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 완료"),
+            @ApiResponse(responseCode = "403", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "관리자 이외의 접근인 경우",
+                            value = "{\"code\": 403, \"message\": \"관리자만 접근이 가능합니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Search {
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminApiDocument.java
@@ -1,0 +1,63 @@
+package teamkiim.koffeechat.domain.corp.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag(name = "[ADMIN] 현직자 인증 도메인 관리 API")
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CorpAdminApiDocument {
+
+    /**
+     * 도메인 등록
+     */
+    @Operation(summary = "현직자 인증 도메인 추가", description = "검증된 회사 도메인을 추가한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "도메인 저장 완료"),
+            @ApiResponse(responseCode = "403", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "관리자 이외의 접근인 경우",
+                            value = "{\"code\": 403, \"message\": \"관리자만 접근이 가능합니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "이미 존재하는 회사 도메인인 경우",
+                            value = "{\"code\": 409, \"message\": \"이미 존재하는 회사 도메인입니다.\"}")}
+            )),
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface EnrollCorpDomain {
+    }
+
+    /**
+     * 도메인 상태 관리 : 승인, 거절
+     */
+    @Operation(summary = "현직자 인증 도메인 상태 관리", description = "사용자가 검증 요청한 도메인에 대해 [승인/ 거절] 상태 관리 한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "도메인 승인/거절 완료"),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "도메인 상태 요청이 올바르지 않은 경우",
+                            value = "{\"code\": 400, \"message\": \"도메인 상태 요청은 WAITING, APPROVED, REJECTED 중에 선택해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "403", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "관리자 이외의 접근인 경우",
+                            value = "{\"code\": 403, \"message\": \"관리자만 접근이 가능합니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "회사 도메인 저장 정보를 찾을 수 없는 경우",
+                            value = "{\"code\": 404, \"message\": \"해당 회사 도메인 정보를 찾을 수 없습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ManageCorpDomain {
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminController.java
@@ -5,22 +5,22 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import teamkiim.koffeechat.domain.corp.controller.admindto.request.EnrollCorpDomainRequest;
 import teamkiim.koffeechat.domain.corp.controller.admindto.request.ManageCorpDomainRequest;
+import teamkiim.koffeechat.domain.corp.controller.admindto.response.AdminCorpDomainListResponse;
 import teamkiim.koffeechat.domain.corp.domain.Verified;
 import teamkiim.koffeechat.domain.corp.service.CorpAdminService;
 import teamkiim.koffeechat.global.Auth;
+
+import java.util.List;
 
 import static teamkiim.koffeechat.global.Auth.MemberRole.ADMIN;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/corp")
-@Tag(name="[ADMIN] 현직자 인증 도메인 관리 API")
+@Tag(name = "[ADMIN] 현직자 인증 도메인 관리 API")
 public class CorpAdminController {
 
     private final CorpAdminService corpAdminService;
@@ -28,25 +28,62 @@ public class CorpAdminController {
     /**
      * 도메인 등록
      */
-    @Auth(role=ADMIN)
+    @Auth(role = ADMIN)
     @PostMapping("/enroll")
     @CorpAdminApiDocument.EnrollCorpDomain
     public ResponseEntity<?> enrollCorpDomain(@Valid @RequestBody EnrollCorpDomainRequest enrollCorpDomainRequest) {
         corpAdminService.saveCorpDomain(enrollCorpDomainRequest.getCorpName(), enrollCorpDomainRequest.getCorpEmailDomain());
 
-        return ResponseEntity.status(HttpStatus.CREATED).body("인증된 도메인이 추가되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body("도메인 등록 완료.");
     }
 
     /**
      * 도메인 상태 관리 : 승인, 거절
      */
-    @Auth(role=ADMIN)
-    @PostMapping("/modify")
+    @Auth(role = ADMIN)
+    @PostMapping("/modify/{corpId}")
     @CorpAdminApiDocument.ManageCorpDomain
-    public ResponseEntity<?> manageCorpDomain(@Valid @RequestBody ManageCorpDomainRequest manageCorpDomainRequest) {
-        Verified verified= corpAdminService.modifyCorpDomain(manageCorpDomainRequest.getCorpName(), manageCorpDomainRequest.getCorpEmailDomain(), manageCorpDomainRequest.getVerified());
+    public ResponseEntity<?> manageCorpDomain(@PathVariable("corpId") Long corpId, @Valid @RequestBody Verified verifiedRequest) {
+        Verified verified = corpAdminService.modifyCorpDomain(corpId, verifiedRequest);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(verified);
     }
+
+    /**
+     * 도메인 삭제
+     */
+    @Auth(role = ADMIN)
+    @PostMapping("/delete/{corpId}")
+    @CorpAdminApiDocument.DeleteCorpDomain
+    public ResponseEntity<?> deleteCorpDomain(@PathVariable("corpId") Long corpId) {
+        corpAdminService.deleteCorpDomain(corpId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("도메인 삭제 완료.");
+    }
+
+    /**
+     * 도메인 목록 출력
+     */
+    @Auth(role = ADMIN)
+    @PostMapping("/list")
+    @CorpAdminApiDocument.List
+    public ResponseEntity<?> list() {
+        List<AdminCorpDomainListResponse> responseList = corpAdminService.list();
+
+        return ResponseEntity.ok().body(responseList);
+    }
+
+    /**
+     * 도메인 검색 : 회사 이름, 이메일
+     */
+    @Auth(role = ADMIN)
+    @PostMapping("/search")
+    @CorpAdminApiDocument.Search
+    public ResponseEntity<?> search(@RequestBody String keyword) {
+        List<AdminCorpDomainListResponse> responseList = corpAdminService.search(keyword);
+
+        return ResponseEntity.ok().body(responseList);
+    }
+
 
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpAdminController.java
@@ -1,0 +1,52 @@
+package teamkiim.koffeechat.domain.corp.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamkiim.koffeechat.domain.corp.controller.admindto.request.EnrollCorpDomainRequest;
+import teamkiim.koffeechat.domain.corp.controller.admindto.request.ManageCorpDomainRequest;
+import teamkiim.koffeechat.domain.corp.domain.Verified;
+import teamkiim.koffeechat.domain.corp.service.CorpAdminService;
+import teamkiim.koffeechat.global.Auth;
+
+import static teamkiim.koffeechat.global.Auth.MemberRole.ADMIN;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/corp")
+@Tag(name="[ADMIN] 현직자 인증 도메인 관리 API")
+public class CorpAdminController {
+
+    private final CorpAdminService corpAdminService;
+
+    /**
+     * 도메인 등록
+     */
+    @Auth(role=ADMIN)
+    @PostMapping("/enroll")
+    @CorpAdminApiDocument.EnrollCorpDomain
+    public ResponseEntity<?> enrollCorpDomain(@Valid @RequestBody EnrollCorpDomainRequest enrollCorpDomainRequest) {
+        corpAdminService.saveCorpDomain(enrollCorpDomainRequest.getCorpName(), enrollCorpDomainRequest.getCorpEmailDomain());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("인증된 도메인이 추가되었습니다.");
+    }
+
+    /**
+     * 도메인 상태 관리 : 승인, 거절
+     */
+    @Auth(role=ADMIN)
+    @PostMapping("/modify")
+    @CorpAdminApiDocument.ManageCorpDomain
+    public ResponseEntity<?> manageCorpDomain(@Valid @RequestBody ManageCorpDomainRequest manageCorpDomainRequest) {
+        Verified verified= corpAdminService.modifyCorpDomain(manageCorpDomainRequest.getCorpName(), manageCorpDomainRequest.getCorpEmailDomain(), manageCorpDomainRequest.getVerified());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(verified);
+    }
+
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpApiDocument.java
@@ -1,0 +1,54 @@
+package teamkiim.koffeechat.domain.corp.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.corp.service.dto.response.CorpDomainResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag(name = "현직자 인증 도메인 관리 API")
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CorpApiDocument {
+
+    /**
+     * 도메인 승인 요청
+     */
+    @Operation(summary = "현직자 인증 도메인 검증 요청", description = "현직자 인증 시 회사 도메인 검증 요청을 한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "도메인 검증 요청 저장 완료"),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 요청한 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface RequestCorpDomain {
+    }
+
+    /**
+     * 회사 도메인 검색
+     */
+    @Operation(summary = "회사 도메인 검색", description = "현직자 인증 시 회사 이름/도메인을 통해 검색한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색된 회사 도메인을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = CorpDomainResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 요청한 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface FindCorpDomain {
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpApiDocument.java
@@ -51,4 +51,44 @@ public @interface CorpApiDocument {
     @Retention(RetentionPolicy.RUNTIME)
     @interface FindCorpDomain {
     }
+
+    /**
+     * 현직자 인증 시 이메일 전송
+     */
+    @Operation(summary = "현직자 인증 시 이메일 인증 메세지 전송", description = "현직자 인증 시 이메일 인증 메세지를 전송한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 요청한 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "이메일이 정상적으로 전송되지 않은 경우",
+                            value = "{\"code\": 500, \"message\": \"이메일 전송에 실패했습니다. 이메일이 올바른지 확인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SendCorpEmail {
+    }
+
+    /**
+     * 회사 이메일 인증 코드 확인
+     */
+    @Operation(summary = "현직자 인증 시 이메일로 전송한 코드 확인", description = "현직자 인증 시 이메일로 전송한 코드를 확인한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 코드 확인 완료"),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "인증 코드가 불일치하는 경우",
+                            value = "{\"code\": 400, \"message\": \"인증 코드가 일치하지 않습니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 요청한 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CheckCorpCode {
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/CorpController.java
@@ -1,0 +1,79 @@
+package teamkiim.koffeechat.domain.corp.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamkiim.koffeechat.domain.corp.controller.dto.request.CorpDomainRequest;
+import teamkiim.koffeechat.domain.corp.controller.dto.request.FindCorpDomainRequest;
+import teamkiim.koffeechat.domain.corp.controller.dto.request.FindCorpNameRequest;
+import teamkiim.koffeechat.domain.corp.service.CorpService;
+import teamkiim.koffeechat.domain.corp.service.dto.response.CorpDomainResponse;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/corp")
+@Tag(name="현직자 인증 API")
+public class CorpController {
+
+    private final CorpService corpService;
+
+    /**
+     * 도메인 승인 요청 -> 대기 상태로 관리자에게 검증 요청
+     */
+    @AuthenticatedMemberPrincipal
+    @PostMapping("/domain")
+    @CorpApiDocument.RequestCorpDomain
+    public ResponseEntity<?> requestCorpDomain(@Valid @RequestBody CorpDomainRequest corpDomainRequest) {
+        String response= corpService.saveCorpRequest(corpDomainRequest.getCorpName(), corpDomainRequest.getCorpEmailDomain());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 회사 도메인 검색
+     */
+    @AuthenticatedMemberPrincipal
+    @PostMapping("/find-corp-mail")
+    @CorpApiDocument.FindCorpDomain
+    public ResponseEntity<?> findCorpDomain(@Valid @RequestBody FindCorpNameRequest corpNameRequest) {
+
+        //회사 이름으로 검색
+        List<CorpDomainResponse> corpList= corpService.findCorpRequest(corpNameRequest.getCorpName());
+
+        if (corpList.isEmpty()) {
+            return ResponseEntity.ok().body("검색 결과가 없습니다. 도메인 검증을 요청해주세요.");
+        }
+
+        return ResponseEntity.ok().body(corpList);
+    }
+
+    @AuthenticatedMemberPrincipal
+    @PostMapping("/find-corp-name")
+    @CorpApiDocument.FindCorpDomain
+    public ResponseEntity<?> findCorpName(@Valid @RequestBody FindCorpDomainRequest corpDomainRequest) {
+
+        //회사 도메인으로 검색
+        List<CorpDomainResponse> corpList= corpService.findCorpNameRequest(corpDomainRequest.getCorpEmailDomain());
+
+        if (corpList.isEmpty()) {
+            return ResponseEntity.ok().body("검색 결과가 없습니다. 도메인 검증을 요청해주세요.");
+        }
+
+        return ResponseEntity.ok().body(corpList);
+    }
+
+
+    /**
+     * 이메일 인증 진행
+     */
+
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/admindto/request/EnrollCorpDomainRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/admindto/request/EnrollCorpDomainRequest.java
@@ -1,0 +1,24 @@
+package teamkiim.koffeechat.domain.corp.controller.admindto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회사 도메인 등록 Request")
+public class EnrollCorpDomainRequest {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    @NotBlank(message = "회사 이름을 입력해주세요")
+    private String corpName;               //회사 이름
+
+    @Schema(description = "회사 도메인", example = "koffeechat.com")
+    @Pattern(regexp = "[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "도메인 형식에 맞게 검색해주세요. \n ex) koffeechat.com, koffeechat.co.kr")
+    @NotBlank(message = "회사 도메인을 입력해주세요")
+    private String corpEmailDomain;        //회사 이메일 도메인
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/admindto/request/ManageCorpDomainRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/admindto/request/ManageCorpDomainRequest.java
@@ -1,0 +1,30 @@
+package teamkiim.koffeechat.domain.corp.controller.admindto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamkiim.koffeechat.domain.corp.domain.Verified;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회사 도메인 승인 상태 변경 Request")
+public class ManageCorpDomainRequest {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    @NotBlank(message = "회사 이름을 입력해주세요")
+    private String corpName;               //회사 이름
+
+    @Schema(description = "회사 도메인", example = "koffeechat.com")
+    @Pattern(regexp = "[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "도메인 형식에 맞게 검색해주세요. \n ex) koffeechat.com, koffeechat.co.kr")
+    @NotBlank(message = "회사 도메인을 입력해주세요")
+    private String corpEmailDomain;        //회사 이메일 도메인
+
+    @Schema(description = "회사 도메인 승인 상태", example = "APPROVED")
+    @NotNull(message = "승인 여부를 선택해주세요")
+    private Verified verified;
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/admindto/response/AdminCorpDomainListResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/admindto/response/AdminCorpDomainListResponse.java
@@ -1,0 +1,38 @@
+package teamkiim.koffeechat.domain.corp.controller.admindto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamkiim.koffeechat.domain.corp.domain.Corp;
+import teamkiim.koffeechat.domain.corp.domain.Verified;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "회사 도메인 리스트 Response")
+public class AdminCorpDomainListResponse {
+
+    @Schema(description = "회사 도메인 pk",example = "1")
+    private Long id;                       //도메인 pk
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    private String corpName;               //회사 이름
+
+    @Schema(description = "회사 도메인", example = "koffeechat.com")
+    private String corpEmailDomain;        //회사 이메일 도메인
+
+    @Schema(description = "도메인 승인 상태", example = "WAITING")
+    private Verified verified;             //상태
+
+    public static AdminCorpDomainListResponse of(Corp corp) {
+        return AdminCorpDomainListResponse.builder()
+                .id(corp.getId())
+                .corpName(corp.getCorpName())
+                .corpEmailDomain(corp.getCorpEmailDomain())
+                .verified(corp.getVerified())
+                .build();
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/CorpAuthCodeCheckRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/CorpAuthCodeCheckRequest.java
@@ -1,0 +1,27 @@
+package teamkiim.koffeechat.domain.corp.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "현직자 이메일 인증 메시지 확인 Request")
+public class CorpAuthCodeCheckRequest {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    @NotBlank(message = "회사 이름을 입력해주세요.")
+    private String corpName;
+
+    @Schema(description = "회사 이메일", example = "koffeechat@naver.com")
+    @NotBlank(message = "회사 이메일을 입력해주세요")
+    private String email;
+
+    @Schema(description = "인증 코드", example = "808080")
+    @NotBlank(message = "인증 코드를 입력해주세요")
+    private String code;
+
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/CorpAuthRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/CorpAuthRequest.java
@@ -1,0 +1,24 @@
+package teamkiim.koffeechat.domain.corp.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "현직자 이메일 인증 메시지 전송 Request")
+public class CorpAuthRequest {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    @NotBlank(message = "회사 이름을 입력해주세요.")
+    private String corpName;
+
+    @Schema(description = "사용자 이메일", example = "koffeechat@naver.com")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해주세요")
+    private String email;
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/CorpDomainRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/CorpDomainRequest.java
@@ -1,0 +1,24 @@
+package teamkiim.koffeechat.domain.corp.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회사 메일 검증 요청 Request")
+public class CorpDomainRequest {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    @NotBlank(message = "회사 이름을 입력해주세요")
+    private String corpName;               //회사 이름
+
+    @Schema(description = "회사 도메인", example = "koffeechat.com")
+    @Pattern(regexp = "[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "도메인 형식에 맞게 검색해주세요. \n ex) koffeechat.com, koffeechat.co.kr")
+    @NotBlank(message = "회사 도메인을 입력해주세요")
+    private String corpEmailDomain;        //회사 이메일 도메인
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/FindCorpDomainRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/FindCorpDomainRequest.java
@@ -1,0 +1,18 @@
+package teamkiim.koffeechat.domain.corp.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회사 이름 검색 Request")
+public class FindCorpDomainRequest {
+
+    @Schema(description = "회사 도메인", example = "koffeechat.com")
+    @Pattern(regexp = "[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "도메인 형식에 맞게 검색해주세요. \n ex) koffeechat.com, koffeechat.co.kr")
+    private String corpEmailDomain;
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/FindCorpNameRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/controller/dto/request/FindCorpNameRequest.java
@@ -1,0 +1,18 @@
+package teamkiim.koffeechat.domain.corp.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회사 도메인 검색 Request")
+public class FindCorpNameRequest {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    private String corpName;
+
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/domain/Corp.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/domain/Corp.java
@@ -13,7 +13,24 @@ public class Corp {
     @Column(name = "corp_id")
     private Long id;
 
-    private String corpName;
+    private String corpName;               //회사 이름
 
-    private String corpEmailDomain;
+    private String corpEmailDomain;        //회사 이메일 도메인
+
+    @Enumerated(EnumType.STRING)
+    private Verified verified;               //이메일 도메인 검증 상태
+
+    /**
+     * 생성자
+     */
+    public Corp(String corpName, String corpEmailDomain, Verified verified) {
+        this.corpName=corpName;
+        this.corpEmailDomain=corpEmailDomain;
+        this.verified=verified;
+    }
+
+    //== 비즈니스 로직 ==//
+    public void statusModify(Verified verified) {
+        this.verified = verified;
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/domain/Verified.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/domain/Verified.java
@@ -1,0 +1,17 @@
+package teamkiim.koffeechat.domain.corp.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Verified {
+
+    WAITING("대기"),
+    APPROVED("승인"),
+    REJECTED("거절");
+
+    private final String status;
+
+    Verified(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/repository/CorpRepository.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/repository/CorpRepository.java
@@ -1,6 +1,8 @@
 package teamkiim.koffeechat.domain.corp.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import teamkiim.koffeechat.domain.corp.domain.Corp;
 import teamkiim.koffeechat.domain.corp.domain.Verified;
 
@@ -14,4 +16,11 @@ public interface CorpRepository extends JpaRepository<Corp, Long> {
     List<Corp> findAllByCorpNameContainingIgnoreCaseAndVerified(String corpName, Verified verified);
 
     List<Corp> findAllByCorpEmailDomainContainingIgnoreCaseAndVerified(String corpDomain, Verified verified);
+
+    Boolean existsByCorpEmailDomainAndVerified(String domain, Verified verified);
+
+    Optional<Corp> findByCorpEmailDomain(String domain);
+
+    @Query("SELECT c FROM Corp c WHERE c.corpName LIKE %:keyword% OR c.corpEmailDomain LIKE %:keyword%")
+    List<Corp> findByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/repository/CorpRepository.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/repository/CorpRepository.java
@@ -1,0 +1,17 @@
+package teamkiim.koffeechat.domain.corp.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamkiim.koffeechat.domain.corp.domain.Corp;
+import teamkiim.koffeechat.domain.corp.domain.Verified;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CorpRepository extends JpaRepository<Corp, Long> {
+
+    Optional<Corp> findByCorpNameAndCorpEmailDomain(String corpName, String corpEmailDomain);
+
+    List<Corp> findAllByCorpNameContainingIgnoreCaseAndVerified(String corpName, Verified verified);
+
+    List<Corp> findAllByCorpEmailDomainContainingIgnoreCaseAndVerified(String corpDomain, Verified verified);
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpAdminService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpAdminService.java
@@ -1,0 +1,40 @@
+package teamkiim.koffeechat.domain.corp.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamkiim.koffeechat.domain.corp.domain.Corp;
+import teamkiim.koffeechat.domain.corp.domain.Verified;
+import teamkiim.koffeechat.domain.corp.repository.CorpRepository;
+import teamkiim.koffeechat.global.exception.CustomException;
+import teamkiim.koffeechat.global.exception.ErrorCode;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CorpAdminService {
+
+    private final CorpRepository corpRepository;
+
+    @Transactional
+    public void saveCorpDomain(String corpName, String corpDomain) {
+        Optional<Corp> corp = corpRepository.findByCorpNameAndCorpEmailDomain(corpName, corpDomain);
+        if (corp.isPresent()) {
+            throw new CustomException(ErrorCode.CORP_ALREADY_EXIST);
+        }
+        Corp corpRequest = new Corp(corpName, corpDomain, Verified.APPROVED);
+        corpRepository.save(corpRequest);
+    }
+
+    @Transactional
+    public Verified modifyCorpDomain(String corpName, String corpEmailDomain, Verified verified) {
+        Corp corp = corpRepository.findByCorpNameAndCorpEmailDomain(corpName, corpEmailDomain)
+                .orElseThrow(()-> new CustomException(ErrorCode.CORP_NOT_FOUND));
+
+        corp.statusModify(verified);
+
+        return corp.getVerified();
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpAdminService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpAdminService.java
@@ -3,13 +3,16 @@ package teamkiim.koffeechat.domain.corp.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import teamkiim.koffeechat.domain.corp.controller.admindto.response.AdminCorpDomainListResponse;
 import teamkiim.koffeechat.domain.corp.domain.Corp;
 import teamkiim.koffeechat.domain.corp.domain.Verified;
 import teamkiim.koffeechat.domain.corp.repository.CorpRepository;
 import teamkiim.koffeechat.global.exception.CustomException;
 import teamkiim.koffeechat.global.exception.ErrorCode;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,12 +32,33 @@ public class CorpAdminService {
     }
 
     @Transactional
-    public Verified modifyCorpDomain(String corpName, String corpEmailDomain, Verified verified) {
-        Corp corp = corpRepository.findByCorpNameAndCorpEmailDomain(corpName, corpEmailDomain)
+    public Verified modifyCorpDomain(Long corpId, Verified verified) {
+        Corp corp = corpRepository.findById(corpId)
                 .orElseThrow(()-> new CustomException(ErrorCode.CORP_NOT_FOUND));
 
         corp.statusModify(verified);
 
         return corp.getVerified();
+    }
+
+    @Transactional
+    public void deleteCorpDomain(Long corpId) {
+        Corp corp = corpRepository.findById(corpId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CORP_NOT_FOUND));
+        corpRepository.delete(corp);
+    }
+
+    public List<AdminCorpDomainListResponse> list() {
+        List<Corp> corpList = corpRepository.findAll();
+
+        List<AdminCorpDomainListResponse> responseList= corpList.stream().map(AdminCorpDomainListResponse::of).toList();
+        return responseList;
+    }
+
+    public List<AdminCorpDomainListResponse> search(String keyword) {
+        List<Corp> corpList = corpRepository.findByKeyword(keyword);
+
+        List<AdminCorpDomainListResponse> responseList= corpList.stream().map(AdminCorpDomainListResponse::of).toList();
+        return responseList;
     }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpService.java
@@ -1,0 +1,65 @@
+package teamkiim.koffeechat.domain.corp.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamkiim.koffeechat.domain.corp.domain.Corp;
+import teamkiim.koffeechat.domain.corp.domain.Verified;
+import teamkiim.koffeechat.domain.corp.repository.CorpRepository;
+import teamkiim.koffeechat.domain.corp.service.dto.response.CorpDomainResponse;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CorpService {
+
+    //corpRepository에 저장되어있는 회사 도메인으로 인증 메일 보내기
+    private final CorpRepository corpRepository;
+
+    /**
+     * 회사 도메인 인증 승인 요청 대기 상태로 저장
+     * 거절된 도메인에 대해 요청하면 -> 요청 거절
+     */
+    @Transactional
+    public String saveCorpRequest(String corpName , String corpDomain){
+
+        Optional<Corp> corp = corpRepository.findByCorpNameAndCorpEmailDomain(corpName, corpDomain);
+
+        if (corp.isPresent()) {  // 이미 있는 요청
+            if(corp.get().getVerified()==Verified.REJECTED) return "승인 거절된 도메인입니다.";
+        }else{                   // 새로운 요청 -> 요청 생성
+            Corp corpRequest = new Corp(corpName, corpDomain, Verified.WAITING);
+            corpRepository.save(corpRequest);
+        }
+
+        return "도메인 검증이 요청되었습니다. 승인이 될 때까지 기다려 주세요.";
+    }
+
+    /**
+     * 회사 도메인 검색 : 회사 검색, 도메인 검색
+     * @param corpName 회사 이름
+     */
+    public List<CorpDomainResponse> findCorpRequest(String corpName) {
+
+        List<Corp> corpList=corpRepository.findAllByCorpNameContainingIgnoreCaseAndVerified(corpName, Verified.APPROVED);
+
+        List<CorpDomainResponse> responseList = corpList.stream().map(CorpDomainResponse::of).collect(Collectors.toList());
+        return responseList;
+    }
+
+    /**
+     * @param corpDomain 회사 도메인
+     */
+    public List<CorpDomainResponse> findCorpNameRequest(String corpDomain) {
+
+        List<Corp> corpList=corpRepository.findAllByCorpEmailDomainContainingIgnoreCaseAndVerified(corpDomain, Verified.APPROVED);
+
+        List<CorpDomainResponse> responseList = corpList.stream().map(CorpDomainResponse::of).collect(Collectors.toList());
+
+        return responseList;
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/service/CorpService.java
@@ -1,12 +1,23 @@
 package teamkiim.koffeechat.domain.corp.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamkiim.koffeechat.domain.corp.domain.Corp;
 import teamkiim.koffeechat.domain.corp.domain.Verified;
 import teamkiim.koffeechat.domain.corp.repository.CorpRepository;
 import teamkiim.koffeechat.domain.corp.service.dto.response.CorpDomainResponse;
+import teamkiim.koffeechat.domain.email.domain.EmailAuth;
+import teamkiim.koffeechat.domain.email.repository.EmailAuthRepository;
+import teamkiim.koffeechat.domain.member.domain.Member;
+import teamkiim.koffeechat.domain.member.repository.MemberRepository;
+import teamkiim.koffeechat.global.exception.CustomException;
+import teamkiim.koffeechat.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,35 +28,42 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CorpService {
 
-    //corpRepository에 저장되어있는 회사 도메인으로 인증 메일 보내기
+    private final MemberRepository memberRepository;
+    private final JavaMailSender javaMailSender;
     private final CorpRepository corpRepository;
+    private final EmailAuthRepository emailAuthRepository;
+
+    @Value("${email-address}")
+    private String hostAddress;                                     // 메일을 보내는 호스트 이메일 주소
 
     /**
-     * 회사 도메인 인증 승인 요청 대기 상태로 저장
+     * 회사 도메인 등록 요청 대기 상태로 저장
      * 거절된 도메인에 대해 요청하면 -> 요청 거절
      */
     @Transactional
-    public String saveCorpRequest(String corpName , String corpDomain){
+    public String saveCorpRequest(String corpName, String corpDomain) {
 
         Optional<Corp> corp = corpRepository.findByCorpNameAndCorpEmailDomain(corpName, corpDomain);
 
         if (corp.isPresent()) {  // 이미 있는 요청
-            if(corp.get().getVerified()==Verified.REJECTED) return "승인 거절된 도메인입니다.";
-        }else{                   // 새로운 요청 -> 요청 생성
+            if (corp.get().getVerified().equals(Verified.REJECTED)) return "승인 거절된 도메인입니다. 이메일 확인 후 문의해주세요.";
+            if(corp.get().getVerified().equals(Verified.APPROVED)) return "이미 존재하는 도메인입니다.";
+        } else {                 // 새로운 요청 -> 요청 생성
             Corp corpRequest = new Corp(corpName, corpDomain, Verified.WAITING);
             corpRepository.save(corpRequest);
         }
 
-        return "도메인 검증이 요청되었습니다. 승인이 될 때까지 기다려 주세요.";
+        return "도메인 등록이 요청되었습니다. 승인이 될 때까지 기다려 주세요.";
     }
 
     /**
      * 회사 도메인 검색 : 회사 검색, 도메인 검색
+     *
      * @param corpName 회사 이름
      */
     public List<CorpDomainResponse> findCorpRequest(String corpName) {
 
-        List<Corp> corpList=corpRepository.findAllByCorpNameContainingIgnoreCaseAndVerified(corpName, Verified.APPROVED);
+        List<Corp> corpList = corpRepository.findAllByCorpNameContainingIgnoreCaseAndVerified(corpName, Verified.APPROVED);
 
         List<CorpDomainResponse> responseList = corpList.stream().map(CorpDomainResponse::of).collect(Collectors.toList());
         return responseList;
@@ -56,10 +74,108 @@ public class CorpService {
      */
     public List<CorpDomainResponse> findCorpNameRequest(String corpDomain) {
 
-        List<Corp> corpList=corpRepository.findAllByCorpEmailDomainContainingIgnoreCaseAndVerified(corpDomain, Verified.APPROVED);
+        List<Corp> corpList = corpRepository.findAllByCorpEmailDomainContainingIgnoreCaseAndVerified(corpDomain, Verified.APPROVED);
 
         List<CorpDomainResponse> responseList = corpList.stream().map(CorpDomainResponse::of).collect(Collectors.toList());
 
         return responseList;
+    }
+
+    /**
+     * 현직자 인증 시 이메일 전송
+     *
+     * @param email
+     * @param memberId
+     */
+    @Transactional
+    public String sendCorpEmailAuthCode(String corpName, String email, Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        String domain = email.substring(email.indexOf('@') + 1);
+        Optional<Corp> corp = corpRepository.findByCorpEmailDomain(domain);
+        if (corp.isEmpty()) {
+            Corp newCorp = new Corp(corpName, domain, Verified.WAITING);
+            corpRepository.save(newCorp);
+            return "등록되어있지 않은 회사입니다. 도메인 승인이 되면 다시 인증해주세요.";
+        }
+
+        if (corp.get().getVerified().equals(Verified.WAITING)) {
+            return "등록 요청이 되어있는 도메인입니다. 도메인 승인이 되면 다시 인증해주세요.";
+        }
+        if (corp.get().getVerified().equals(Verified.REJECTED)) {
+            return "인증할 수 없는 도메인입니다. 이메일을 확인 후 문의해주세요.";
+        }
+
+        //인증된 도메인인 경우 메일 발송
+        EmailAuth emailAuth = new EmailAuth(email);
+        emailAuthRepository.save(emailAuth);
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper;
+
+        try {
+            mimeMessageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+            mimeMessageHelper.setFrom(hostAddress);
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("[KoffeChat] 이메일 인증 서비스");
+
+            StringBuilder emailBody = new StringBuilder();
+            emailBody.append("<!DOCTYPE html>");
+            emailBody.append("<html lang='ko'>");
+            emailBody.append("<head>");
+            emailBody.append("<meta charset='UTF-8'>");
+            emailBody.append("<meta name='viewport' content='width=device-width, initial-scale=1.0'>");
+            emailBody.append("<title>이메일 인증</title>");
+            emailBody.append("</head>");
+            emailBody.append("<body style='font-family: Arial, sans-serif; background-color: #f3f4f6; margin: 0; padding: 0;'>");
+            emailBody.append("<div style='max-width: 600px; margin: 40px auto; background-color: #ffffff; box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1); border-radius: 10px; overflow: hidden;'>");
+            emailBody.append("<div style='background-color: #7c3aed; color: white; padding: 25px; text-align: center;'>");
+            emailBody.append("<h1 style='margin: 0; font-size: 26px; font-weight: bold;'>KoffeeChat 이메일 인증</h1>");
+            emailBody.append("</div>");
+            emailBody.append("<div style='padding: 40px; text-align: center;'>");
+            emailBody.append("<h2 style='color: #333; font-size: 22px; margin-top: 0;'>안녕하세요, " + member.getNickname() + " 님</h2>");
+            emailBody.append("<p style='color: #555; font-size: 16px; line-height: 1.6; margin: 20px 0;'><strong>[KoffeeChat]</strong> 이메일 인증 서비스 입니다.</p>");
+            emailBody.append("<p style='color: #555; font-size: 16px; line-height: 1.6;'>홈페이지로 돌아가서 다음 인증코드를 입력해주세요.</p>");
+            emailBody.append("<div style='display: inline-block; margin: 30px 0; padding: 15px 30px; background-color: #e3f2fd; border: 2px solid #7c3aed; border-radius: 5px; font-size: 20px; letter-spacing: 2px; color: #7c3aed; text-align: center;'>" + emailAuth.getCode() + "</div>");
+            emailBody.append("</div>");
+            emailBody.append("<div style='background-color: #f1f3f4; color: #555; text-align: center; padding: 20px; font-size: 12px; border-top: 1px solid #ddd;'>");
+            emailBody.append("<p>&copy; 2024 KoffeChat. All rights reserved.</p>");
+            emailBody.append("</div>");
+            emailBody.append("</div>");
+            emailBody.append("</body>");
+            emailBody.append("</html>");
+
+            mimeMessageHelper.setText(emailBody.toString(), true);          //html형식으로 설정
+
+            javaMailSender.send(mimeMessage);
+
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorCode.CANNOT_SEND_EMAIL);
+        }
+
+        return "이메일 전송 완료, 이메일을 확인해주세요";
+    }
+
+    /**
+     * 현직자 인증 시 이메일 인증코드 확인
+     *
+     * @param email 회원의 회사 이메일
+     * @param code  회사 이메일 인증 코드
+     */
+    @Transactional
+    public String checkCorpEmailAuthCode(Long memberId, String corpName, String email, String code) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        EmailAuth emailAuth = emailAuthRepository.findByEmailAndCode(email, code)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_CODE_NOT_MATCH));
+
+        emailAuthRepository.delete(emailAuth);
+
+        member.authCorp(corpName, email);
+
+        return "인증 되었습니다.";
     }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/corp/service/dto/response/CorpDomainResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/corp/service/dto/response/CorpDomainResponse.java
@@ -1,0 +1,32 @@
+package teamkiim.koffeechat.domain.corp.service.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamkiim.koffeechat.domain.corp.domain.Corp;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회사 메일 검색 Response")
+@Builder
+public class CorpDomainResponse {
+
+    @Schema(description = "회사 이름", example = "커피챗")
+    private String corpName;               //회사 이름
+
+    @Schema(description = "회사 도메인", example = "koffeechat.com")
+    private String corpEmailDomain;        //회사 이메일 도메인
+
+    public static CorpDomainResponse of(Corp corp) {
+        CorpDomainResponse response= CorpDomainResponse.builder()
+                .corpName(corp.getCorpName())
+                .corpEmailDomain(corp.getCorpEmailDomain())
+                .build();
+        return response;
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailApiDocument.java
@@ -37,7 +37,7 @@ public @interface EmailApiDocument {
      */
     @Operation(summary = "회원가입 시 이메일로 전송한 코드 확인", description = "회원가입 시 이메일로 전송한 코드를 확인한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
+            @ApiResponse(responseCode = "200", description = "인증 코드 확인 완료"),
             @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
                     examples = {@ExampleObject(name = "인증 코드가 불일치하는 경우",
                             value = "{\"code\": 400, \"message\": \"인증 코드가 일치하지 않습니다.\"}")}

--- a/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailApiDocument.java
@@ -1,5 +1,10 @@
 package teamkiim.koffeechat.domain.email.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.lang.annotation.ElementType;
@@ -12,5 +17,34 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EmailApiDocument {
 
+    /**
+     * 회원가입 시 이메일 인증 메세지 전송
+     */
+    @Operation(summary = "회원가입 시 이메일 인증 메세지 전송", description = "회원가입 시 인증 이메일을 전송한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "이메일이 정상적으로 전송되지 않은 경우",
+                            value = "{\"code\": 500, \"message\": \"이메일 전송에 실패했습니다. 이메일이 올바른지 확인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SendAuthEmail {}
+
+    /**
+     * 이메일 인증 진행
+     */
+    @Operation(summary = "회원가입 시 이메일로 전송한 코드 확인", description = "회원가입 시 이메일로 전송한 코드를 확인한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "인증 코드가 불일치하는 경우",
+                            value = "{\"code\": 400, \"message\": \"인증 코드가 일치하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CheckAuthCode {}
 
 }

--- a/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailController.java
@@ -1,15 +1,13 @@
 package teamkiim.koffeechat.domain.email.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import teamkiim.koffeechat.domain.email.controller.dto.AuthCodeCheckRequest;
 import teamkiim.koffeechat.domain.email.dto.request.EmailAuthRequest;
 import teamkiim.koffeechat.domain.email.service.EmailService;

--- a/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/controller/EmailController.java
@@ -26,14 +26,7 @@ public class EmailController {
      * 회원가입 시 이메일 인증 메세지 전송
      */
     @PostMapping("/send-auth-code")
-    @Operation(summary = "회원가입 시 이메일 인증 메세지 전송", description = "회원가입 시 인증 이메일을 전송한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
-            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "이메일이 정상적으로 전송되지 않은 경우",
-                            value = "{\"code\": 500, \"message\": \"이메일 전송에 실패했습니다. 이메일이 올바른지 확인해주세요.\"}")}
-            ))
-    })
+    @EmailApiDocument.SendAuthEmail
     public ResponseEntity<?> sendAuthEmail(@Valid @RequestBody EmailAuthRequest emailAuthRequest){
 
         return emailService.sendEmailAuthCode(emailAuthRequest.getEmail());
@@ -43,14 +36,7 @@ public class EmailController {
      * 이메일 인증 진행
      */
     @PostMapping("/check-auth-code")
-    @Operation(summary = "회원가입 시 이메일로 전송한 코드 확인", description = "회원가입 시 이메일로 전송한 코드를 확인한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "인증 코드가 불일치하는 경우",
-                            value = "{\"code\": 400, \"message\": \"인증 코드가 일치하지 않습니다.\"}")}
-            ))
-    })
+    @EmailApiDocument.CheckAuthCode
     public ResponseEntity<?> checkAuthCode(@Valid @RequestBody AuthCodeCheckRequest authCodeCheckRequest){
 
         return emailService.checkEmailAuthCode(authCodeCheckRequest.toServiceRequest());

--- a/src/main/java/teamkiim/koffeechat/domain/email/controller/dto/AuthCodeCheckRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/controller/dto/AuthCodeCheckRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.email.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,10 +10,14 @@ import teamkiim.koffeechat.domain.email.dto.request.AuthCodeCheckServiceRequest;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "이메일 인증 메시지 확인 Request")
 public class AuthCodeCheckRequest {
 
+    @Schema(description = "사용자 이메일", example = "koffeechat@naver.com")
     @NotBlank(message = "이메일을 입력해주세요")
     private String email;
+
+    @Schema(description = "인증 코드", example = "808080")
     @NotBlank(message = "인증 코드를 입력해주세요")
     private String code;
 

--- a/src/main/java/teamkiim/koffeechat/domain/email/dto/request/EmailAuthRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/dto/request/EmailAuthRequest.java
@@ -1,6 +1,8 @@
 package teamkiim.koffeechat.domain.email.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +14,7 @@ import lombok.NoArgsConstructor;
 public class EmailAuthRequest {
 
     @Schema(description = "사용자 이메일", example = "koffeechat@naver.com")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해주세요")
     private String email;
 }

--- a/src/main/java/teamkiim/koffeechat/domain/email/dto/request/EmailAuthRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/email/dto/request/EmailAuthRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.email.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,7 +8,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "이메일 인증 메시지 전송 Request")
 public class EmailAuthRequest {
 
+    @Schema(description = "사용자 이메일", example = "koffeechat@naver.com")
     private String email;
 }

--- a/src/main/java/teamkiim/koffeechat/domain/file/controller/FileApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/file/controller/FileApiDocument.java
@@ -1,6 +1,13 @@
 package teamkiim.koffeechat.domain.file.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.file.dto.response.ImagePathResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +18,29 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface FileApiDocument {
+
+    /**
+     * 이미지 단건 저장
+     */
+    @Operation(summary = "이미지 파일 단건 저장", description = "이미지 파일을 단건 저장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성된 이미지 파일의 정보를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = ImagePathResponse.class))),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "FILE I/O 에러가 난 경우",
+                            value = "{\"code\":500, \"message\":\"파일 저장에 실패했습니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "파일 디렉토리가 존재하지 않거나, 파일 형식이 잘못된 경우",
+                            value = "{\"code\":400, \"message\":\"파일 요청이 올바르지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SaveImageFile {}
+
 }

--- a/src/main/java/teamkiim/koffeechat/domain/file/controller/FileController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/file/controller/FileController.java
@@ -1,19 +1,15 @@
 package teamkiim.koffeechat.domain.file.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import teamkiim.koffeechat.domain.file.service.FileService;
-import teamkiim.koffeechat.domain.file.dto.response.ImagePathResponse;
-import teamkiim.koffeechat.global.Auth;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,28 +22,11 @@ public class FileController {
     /**
      * 이미지 단건 저장
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/image")
-    @Operation(summary = "이미지 파일 단건 저장", description = "이미지 파일을 단건 저장한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 이미지 파일의 정보를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = ImagePathResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            )),
-            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "FILE I/O 에러가 난 경우",
-                            value = "{\"code\":500, \"message\":\"파일 저장에 실패했습니다.\"}")}
-            )),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "파일 디렉토리가 존재하지 않거나, 파일 형식이 잘못된 경우",
-                            value = "{\"code\":400, \"message\":\"파일 요청이 올바르지 않습니다.\"}")}
-            ))
-    })
+    @FileApiDocument.SaveImageFile
     public ResponseEntity<?> saveImageFile(@RequestPart(value = "file") MultipartFile multipartFile,
-                                           @RequestPart(value = "postId") Long postId){
+                                           @RequestPart(value = "postId") Long postId) {
 
         return fileService.saveImageFile(multipartFile, postId);
     }

--- a/src/main/java/teamkiim/koffeechat/domain/file/service/FileStorageControlService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/file/service/FileStorageControlService.java
@@ -55,7 +55,7 @@ public class FileStorageControlService {
     /**
      * 회원 프로필 이미지 단건 저장
      * @param multipartFile 실제 파일
-     * @param memberId 회원 PK
+     * @param member 회원
      */
     public ProfileImageInfoResponse saveFile(Member member, MultipartFile multipartFile){
 

--- a/src/main/java/teamkiim/koffeechat/domain/member/controller/MemberApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/controller/MemberApiDocument.java
@@ -1,6 +1,15 @@
 package teamkiim.koffeechat.domain.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import teamkiim.koffeechat.domain.file.dto.response.ProfileImageInfoResponse;
+import teamkiim.koffeechat.domain.member.dto.response.MemberInfoResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +20,103 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MemberApiDocument {
+
+    /**
+     * 프로필 사진 등록
+     */
+    @Operation(summary = "회원 프로필 사진 등록", description = "사용자가 프로필 사진을 등록한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "프로필 사진의 정보가 반환된다.",
+                    content = @Content(schema = @Schema(implementation = ProfileImageInfoResponse.class))),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "프로필 사진 파일이 잘못된 경우",
+                            value = "{\"code\":400, \"message\":\"사진 파일 요청이 올바르지 않습니다.\"}")}
+            )),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 프로필 사진을 등록하려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "파일 저장에 실패한 경우",
+                            value = "{\"code\":500, \"message\":\"파일 저장에 실패했습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SaveProfileImage { }
+
+    /**
+     * 관심 기술 카테고리 등록
+     */
+    @Operation(summary = "회원의 관심 기술 카테고리 저장", description = "사용자가 자신의 관심 기술 카테고리를 저장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원 관심 기술 설정 완료.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 관심 기술 카테고리를 설정하려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface EnrollSkills { }
+
+    /**
+     * 본인 프로필 조회
+     */
+    @Operation(summary = "본인 프로필 조회", description = "사용자가 본인의 프로필을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청한 회원 프로필 정보를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = MemberInfoResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 프로필 조회를 시도하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface FindProfile { }
+
+    /**
+     * 타회원 프로필 조회
+     */
+    @Operation(summary = "타회원 프로필 조회", description = "사용자가 타회원의 프로필을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청한 회원 프로필 정보를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = MemberInfoResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 프로필 조회를 시도하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface FindMemberProfile { }
+
+    /**
+     * 프로필 수정
+     */
+    @Operation(summary = "회원 정보 수정", description = "사용자가 본인의 프로필 정보를 수정한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원 정보 수정 완료"),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ModifyProfile { }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/member/controller/MemberApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/controller/MemberApiDocument.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.boot.configurationprocessor.json.JSONObject;
 import teamkiim.koffeechat.domain.file.dto.response.ProfileImageInfoResponse;
 import teamkiim.koffeechat.domain.member.dto.response.MemberInfoResponse;
 

--- a/src/main/java/teamkiim/koffeechat/domain/member/controller/MemberController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/controller/MemberController.java
@@ -1,11 +1,5 @@
 package teamkiim.koffeechat.domain.member.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -13,13 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import teamkiim.koffeechat.domain.file.dto.response.ProfileImageInfoResponse;
 import teamkiim.koffeechat.domain.member.controller.dto.EnrollSkillCategoryRequest;
-import teamkiim.koffeechat.domain.member.dto.response.MemberInfoResponse;
-import teamkiim.koffeechat.global.Auth;
 import teamkiim.koffeechat.domain.member.controller.dto.ModifyProfileRequest;
 import teamkiim.koffeechat.domain.member.dto.request.EnrollSkillCategoryServiceRequest;
 import teamkiim.koffeechat.domain.member.service.MemberService;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,28 +27,11 @@ public class MemberController {
     /**
      * 프로필 사진 등록
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/enroll-profile-image")
-    @Operation(summary = "회원 프로필 사진 등록", description = "사용자가 프로필 사진을 등록한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "프로필 사진의 정보가 반환된다.",
-                    content = @Content(schema = @Schema(implementation = ProfileImageInfoResponse.class))),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "파일이 잘못된 경우",
-                            value = "{\"code\":404, \"message\":\"파일 요청이 올바르지 않습니다.\"}")}
-            )),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "파일 저장에 실패한 경우",
-                            value = "{\"code\":404, \"message\":\"파일 저장에 실패했습니다.\"}")}
-            ))
-    })
+    @MemberApiDocument.SaveProfileImage
     public ResponseEntity<?> saveProfileImage(@RequestPart(value = "file") MultipartFile multipartFile,
-                                              HttpServletRequest request){
+                                              HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
 
@@ -66,24 +41,11 @@ public class MemberController {
     /**
      * 관심 기술 카테고리 등록
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/enroll-skills")
-    @Operation(summary = "회원의 관심 기술 카테고리 저장", description = "사용자가 자신의 관심 기술 카테고리를 저장한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 게시글의 PK를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
-    public ResponseEntity<?> enrollSkils(@Valid @RequestBody List<EnrollSkillCategoryRequest> enrollSkillCategoryRequest,
-                                         HttpServletRequest request){
+    @MemberApiDocument.EnrollSkills
+    public ResponseEntity<?> enrollSkills(@Valid @RequestBody List<EnrollSkillCategoryRequest> enrollSkillCategoryRequest,
+                                          HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
 
@@ -97,23 +59,10 @@ public class MemberController {
     /**
      * 본인 프로필 조회
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @GetMapping("/profile")
-    @Operation(summary = "본인 프로필 조회", description = "사용자가 본인의 프로필을 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요청한 회원 프로필 정보를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = MemberInfoResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 프로필 조회를 시도하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
-    public ResponseEntity<?> findProfile(HttpServletRequest request){
+    @MemberApiDocument.FindProfile
+    public ResponseEntity<?> findProfile(HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
 
@@ -123,23 +72,10 @@ public class MemberController {
     /**
      * 타회원 프로필 조회
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @GetMapping("/profile/{profileMemberId}")
-    @Operation(summary = "타회원 프로필 조회", description = "사용자가 타회원의 프로필을 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요청한 회원 프로필 정보를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = MemberInfoResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 프로필 조회를 시도하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
-    public ResponseEntity<?> findProfile(@PathVariable("profileMemberId") Long profileMemberId, HttpServletRequest request){
+    @MemberApiDocument.FindMemberProfile
+    public ResponseEntity<?> findProfile(@PathVariable("profileMemberId") Long profileMemberId, HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
 
@@ -149,17 +85,10 @@ public class MemberController {
     /**
      * 프로필 수정
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PatchMapping("/profile")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원 정보 수정 완료"),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
-    public ResponseEntity<?> modifyProfile(@Valid @RequestBody ModifyProfileRequest modifyProfileRequest, HttpServletRequest request){
+    @MemberApiDocument.ModifyProfile
+    public ResponseEntity<?> modifyProfile(@Valid @RequestBody ModifyProfileRequest modifyProfileRequest, HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
 
@@ -167,7 +96,7 @@ public class MemberController {
     }
 
     @GetMapping("/test")
-    public void test(){
+    public void test() {
         System.out.println("테스트 통과");
     }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/member/controller/dto/ModifyProfileRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/controller/dto/ModifyProfileRequest.java
@@ -1,7 +1,9 @@
 package teamkiim.koffeechat.domain.member.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,10 +13,15 @@ import teamkiim.koffeechat.domain.member.domain.MemberRole;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "회원 프로필 수정 Request")
 public class ModifyProfileRequest {
 
+    @Schema(description = "회원 닉네임 수정", example ="커피챗수정" )
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣_.-]{3,10}$", message = "닉네임은 3~10자의 알파벳 대소문자, 숫자, _ . -만 사용 가능합니다.")
     @NotBlank(message = "닉네임 입력은 필수입니다")
     private String nickname;
+
+    @Schema(description = "회원 직업 수정")
     @NotNull(message = "회원 직업 입력은 필수입니다")
     private MemberRole memberRole;
 

--- a/src/main/java/teamkiim/koffeechat/domain/member/domain/Member.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/domain/Member.java
@@ -62,6 +62,8 @@ public class Member {
         this.followerCount= followerCount;
         this.followingCount=followingCount;
         this.profileImageName = profileImageName;
+        this.corpName= null;
+        this.corpEmail=null;
     }
 
     //== 비지니스 로직 ==//
@@ -107,4 +109,12 @@ public class Member {
     public void removeFollowerCount(){this.followerCount--;}
     public void addFollowingCount(){this.followingCount++;}
     public void removeFollowingCount(){this.followingCount--;}
+
+    /**
+     * 현직자 인증
+     */
+    public void authCorp(String corpName, String corpEmail) {
+        this.corpName= corpName;
+        this.corpEmail= corpEmail;
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/member/domain/Member.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/domain/Member.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import teamkiim.koffeechat.domain.corp.domain.Corp;
 import teamkiim.koffeechat.domain.post.dev.domain.SkillCategory;
 
 import java.util.ArrayList;
@@ -42,6 +43,9 @@ public class Member {
     private final String profileImagePath = "PROFILE";
 
     private String profileImageName;
+
+    private String corpName;                                        //회사 이름
+    private String corpEmail;                                       //회사 이메일
 
     @Builder
     public Member(String email, String password, String nickname, MemberRole memberRole,

--- a/src/main/java/teamkiim/koffeechat/domain/member/service/MemberService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package teamkiim.koffeechat.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +44,7 @@ public class MemberService {
 
         member.modify(modifyProfileServiceRequest.getNickname(), modifyProfileServiceRequest.getMemberRole());
 
-        return ResponseEntity.ok("회원 정보 수정 완료");
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원 정보 수정 완료");
     }
 
     /**
@@ -65,7 +66,7 @@ public class MemberService {
 
         member.enrollSkillCategory(skillCategoryList);
 
-        return ResponseEntity.ok("관심 기술 설정 완료");
+        return ResponseEntity.status(HttpStatus.CREATED).body("관심 기술 설정 완료");
     }
 
     /**
@@ -84,7 +85,7 @@ public class MemberService {
 
         member.enrollProfileImage(response.getProfileImageName());
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /**

--- a/src/main/java/teamkiim/koffeechat/domain/memberfollow/controller/MemberFollowApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/memberfollow/controller/MemberFollowApiDocument.java
@@ -1,6 +1,14 @@
 package teamkiim.koffeechat.domain.memberfollow.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.member.dto.response.MemberInfoResponse;
+import teamkiim.koffeechat.domain.memberfollow.service.dto.MemberFollowListResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +19,57 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MemberFollowApiDocument {
+
+    /**
+     * 팔로우
+     */
+    @Operation(summary = "회원 팔로우", description = "사용자가 다른 사용자를 팔로우/팔로우 취소한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "다른 사용자의 팔로워 수를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 구독을 누르는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MemberFollow { }
+
+    /**
+     * 사용자 follower list 확인
+     */
+    @Operation(summary = "회원 팔로워 목록 확인", description = "사용자가 특정 회원의 팔로워 목록을 확인한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원의 팔로워 리스트를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = MemberFollowListResponse.class))),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface FollowerList { }
+
+    /**
+     * 사용자 following list 확인
+     */
+    @Operation(summary = "회원 팔로잉 목록 확인", description = "사용자가 특정 회원의 팔로잉 목록을 확인한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원의 팔로잉 리스트를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = MemberFollowListResponse.class))),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface FollowingList { }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/memberfollow/controller/MemberFollowController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/memberfollow/controller/MemberFollowController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import teamkiim.koffeechat.global.Auth;
 import teamkiim.koffeechat.domain.memberfollow.service.MemberFollowService;
 import teamkiim.koffeechat.domain.memberfollow.service.dto.MemberFollowListResponse;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,23 +27,9 @@ public class MemberFollowController {
     /**
      * 팔로우
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/{memberId}")
-    @Operation(summary = "회원 팔로우", description = "사용자가 다른 사용자를 팔로우/팔로우 취소한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다른 사용자의 팔로워 수를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 구독을 누르는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-
-            ))
-    })
+    @MemberFollowApiDocument.MemberFollow
     public ResponseEntity<?> memberFollow(@PathVariable("memberId") Long followingMemberId, HttpServletRequest request) {
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
 
@@ -54,15 +41,7 @@ public class MemberFollowController {
      */
     @Auth(role={})
     @GetMapping("/follower-list/{memberId}")
-    @Operation(summary = "회원 팔로워 목록 확인", description = "사용자가 특정 회원의 팔로워 목록을 확인한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원의 팔로워 리스트를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = MemberFollowListResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
+    @MemberFollowApiDocument.FollowerList
     public ResponseEntity<?> followerList(@PathVariable("memberId") Long memberId, @RequestParam("page") int page, @RequestParam("size") int size, HttpServletRequest request) {
 
         Long loginMemberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -75,15 +54,7 @@ public class MemberFollowController {
      */
     @Auth(role={})
     @GetMapping("/following-list/{memberId}")
-    @Operation(summary = "회원 팔로잉 목록 확인", description = "사용자가 특정 회원의 팔로잉 목록을 확인한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원의 팔로잉 리스트를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = MemberFollowListResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
+    @MemberFollowApiDocument.FollowingList
     public ResponseEntity<?> followingList(@PathVariable("memberId") Long memberId, @RequestParam("page") int page, @RequestParam("size") int size, HttpServletRequest request) {
 
         Long loginMemberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));

--- a/src/main/java/teamkiim/koffeechat/domain/memberfollow/service/MemberFollowService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/memberfollow/service/MemberFollowService.java
@@ -3,6 +3,7 @@ package teamkiim.koffeechat.domain.memberfollow.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,7 +55,7 @@ public class MemberFollowService {
             member.addFollowingCount();             //회원의 팔로잉 수 ++
             followingMember.addFollowerCount();     //회원이 구독한 회원의 팔로워 수 ++
         }
-        return ResponseEntity.ok(followingMember.getFollowerCount());
+        return ResponseEntity.status(HttpStatus.CREATED).body(followingMember.getFollowerCount());
     }
 
     /**

--- a/src/main/java/teamkiim/koffeechat/domain/oauth/controller/OAuthApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/oauth/controller/OAuthApiDocument.java
@@ -1,6 +1,14 @@
 package teamkiim.koffeechat.domain.oauth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import teamkiim.koffeechat.domain.oauth.dto.response.SocialMemberInfoResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +19,58 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OAuthApiDocument {
+
+    /**
+     * 카카오 인증 코드로 카카오 서버에 access, refresh 토큰 요청
+     */
+    @Operation(summary = "카카오 인증 코드로 엑세스 토큰 발급", description = "카카오 인증 코드로 access, refresh 토큰을 발급받는다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = JSONObject.class))),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "외부 API로 부터 응답으로 받은 JSON 데이터에 문제가 있을 경우",
+                            value = "{\"code\": 500, \"message\": \"소셜 로그인 사용자 정보 json 파싱 에러\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface GetKakaoAccessTokenFromCode { }
+
+    /**
+     * 구글 인증 코드로 구글 서버에 access, refresh 토큰 요청
+     */
+    @Operation(summary = "구글 인증 코드로 엑세스 토큰 발급", description = "카카오 인증 코드로 access, refresh 토큰을 발급받는다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = JSONObject.class))),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "외부 API로 부터 응답으로 받은 JSON 데이터에 문제가 있을 경우",
+                            value = "{\"code\": 500, \"message\": \"소셜 로그인 사용자 정보 json 파싱 에러\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface GetGoogleAccessTokenFromCode { }
+
+    /**
+     * 소셜 로그인 인증 서버로부터 발급받은 Access 토큰을 이용하여 소셜 로그인 회원의 회원정보 조회
+     */
+    @Operation(summary = "소셜 로그인 회원 정보 조회", description = "소셜 로그인 서버 엑세스 토큰을 이용해 사용자 정보를 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SocialMemberInfoResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "외부 API로 부터 응답으로 받은 JSON 데이터에 문제가 있을 경우",
+                            value = "{\"code\": 500, \"message\": \"소셜 로그인 사용자 정보 json 파싱 에러\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface GetAccessTokenAndGetMemberInfo { }
+
+    /**
+     * 소셜 로그인 회원의 로그인/회원가입
+     */
+    @Operation(summary = "소셜 로그인 회원 로그인/회원가입", description = "회원의 이메일, 닉네임 정보로 로그인/회원가입을 진행한다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "로그인/회원가입 성공")})
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SocialLogin { }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/oauth/controller/OAuthController.java
@@ -1,19 +1,15 @@
 package teamkiim.koffeechat.domain.oauth.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.configurationprocessor.json.JSONObject;
-import org.springframework.http.*;
-import org.springframework.web.bind.annotation.*;
-import teamkiim.koffeechat.domain.oauth.dto.response.SocialMemberInfoResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import teamkiim.koffeechat.domain.oauth.controller.dto.GoogleAuthRequest;
 import teamkiim.koffeechat.domain.oauth.controller.dto.KakaoAuthRequest;
 import teamkiim.koffeechat.domain.oauth.controller.dto.SaveSocialLoginMemberInfoRequest;
@@ -32,15 +28,8 @@ public class OAuthController {
      * 카카오 인증 코드로 카카오 서버에 access, refresh 토큰 요청
      */
     @PostMapping("/get-kakao-code")
-    @Operation(summary = "카카오 인증 코드로 엑세스 토큰 발급", description = "카카오 인증 코드로 access, refresh 토큰을 발급받는다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = JSONObject.class))),
-            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "외부 API로 부터 응답으로 받은 JSON 데이터에 문제가 있을 경우",
-                            value = "{\"code\": 500, \"message\": \"소셜 로그인 사용자 정보 json 파싱 에러\"}")}
-            ))
-    })
-    public ResponseEntity<?> getKakaoAccessTokenFromCode(@Valid @RequestBody KakaoAuthRequest kakaoAuthRequest){
+    @OAuthApiDocument.GetKakaoAccessTokenFromCode
+    public ResponseEntity<?> getKakaoAccessTokenFromCode(@Valid @RequestBody KakaoAuthRequest kakaoAuthRequest) {
 
         return oAuthService.getKakaoJWT(kakaoAuthRequest.toServiceRequest());
     }
@@ -49,15 +38,8 @@ public class OAuthController {
      * 구글 인증 코드로 구글 서버에 access, refresh 토큰 요청
      */
     @PostMapping("/get-google-code")
-    @Operation(summary = "구글 인증 코드로 엑세스 토큰 발급", description = "카카오 인증 코드로 access, refresh 토큰을 발급받는다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = JSONObject.class))),
-            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "외부 API로 부터 응답으로 받은 JSON 데이터에 문제가 있을 경우",
-                            value = "{\"code\": 500, \"message\": \"소셜 로그인 사용자 정보 json 파싱 에러\"}")}
-            ))
-    })
-    public ResponseEntity<?> getGoogleAccessTokenFromCode(@Valid @RequestBody GoogleAuthRequest googleAuthRequest){
+    @OAuthApiDocument.GetGoogleAccessTokenFromCode
+    public ResponseEntity<?> getGoogleAccessTokenFromCode(@Valid @RequestBody GoogleAuthRequest googleAuthRequest) {
 
         return oAuthService.getGoogleJWT(googleAuthRequest.toServiceRequest());
     }
@@ -66,19 +48,12 @@ public class OAuthController {
      * 소셜 로그인 인증 서버로부터 발급받은 Access 토큰을 이용하여 소셜 로그인 회원의 회원정보 조회
      */
     @PostMapping("/get-member-info")
-    @Operation(summary = "소셜 로그인 회원 정보 조회", description = "소셜 로그인 서버 엑세스 토큰을 이용해 사용자 정보를 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SocialMemberInfoResponse.class))),
-            @ApiResponse(responseCode = "500", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "외부 API로 부터 응답으로 받은 JSON 데이터에 문제가 있을 경우",
-                            value = "{\"code\": 500, \"message\": \"소셜 로그인 사용자 정보 json 파싱 에러\"}")}
-            ))
-    })
-    public ResponseEntity<?> getAccessTokenAndGetMemberInfo(@Valid @RequestBody SocialAccessTokenRequest socialAccessTokenRequest){
+    @OAuthApiDocument.GetAccessTokenAndGetMemberInfo
+    public ResponseEntity<?> getAccessTokenAndGetMemberInfo(@Valid @RequestBody SocialAccessTokenRequest socialAccessTokenRequest) {
 
         ResponseEntity<?> response;
 
-        switch (socialAccessTokenRequest.getSocialLoginType()){
+        switch (socialAccessTokenRequest.getSocialLoginType()) {
             case NAVER -> response = oAuthService.getMemberInfoFromNaver(socialAccessTokenRequest.getAccessToken());
             case KAKAO -> response = oAuthService.getMemberInfoFromKakao(socialAccessTokenRequest.getAccessToken());
             case GOOGLE -> response = oAuthService.getMemberInfoFromGoogle(socialAccessTokenRequest.getAccessToken());
@@ -92,10 +67,9 @@ public class OAuthController {
      * 소셜 로그인 회원의 로그인/회원가입
      */
     @PostMapping("/login")
-    @Operation(summary = "소셜 로그인 회원 로그인/회원가입", description = "회원의 이메일, 닉네임 정보로 로그인/회원가입을 진행한다.")
-    @ApiResponses({ @ApiResponse(responseCode = "200", description = "로그인/회원가입 성공") })
+    @OAuthApiDocument.SocialLogin
     public ResponseEntity<?> socialLogin(@Valid @RequestBody SaveSocialLoginMemberInfoRequest saveSocialLoginMemberInfoRequest,
-                                                    HttpServletResponse response){
+                                         HttpServletResponse response) {
 
         return oAuthService.loginOrSignUpSocialMember(saveSocialLoginMemberInfoRequest.toServiceRequest(), response);
     }

--- a/src/main/java/teamkiim/koffeechat/domain/post/common/controller/PostApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/common/controller/PostApiDocument.java
@@ -1,6 +1,13 @@
 package teamkiim.koffeechat.domain.post.common.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.post.common.dto.response.BookmarkPostListResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +18,83 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PostApiDocument {
+
+    /**
+     * 좋아요
+     */
+    @Operation(summary = "게시글 좋아요", description = "사용자가 개발, 커뮤니티 게시판에 좋아요를 누른다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "게시물 좋아요 수를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 좋아요를 누르는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "게시물을 찾을 수 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 게시물이 존재하지 않습니다\"}")}
+
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface LikeApiDoc {
+    }
+
+    /**
+     * 북마크
+     */
+    @Operation(summary = "게시글 북마크", description = "사용자가 개발, 커뮤니티 게시판에 북마크를 누른다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "게시물 북마크 수를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 북마크를 누르는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "게시물을 찾을 수 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 게시물이 존재하지 않습니다\"}")}
+
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface BookmarkApiDoc {
+    }
+
+    /**
+     * 북마크 리스트 조회
+     */
+    @Operation(summary = "사용자 북마크 게시물 리스트 조회", description = "로그인한 사용자의 북마크 게시물 리스트롤 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "북마크한 게시물 리스트를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = BookmarkPostListResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 북마크 리스트를 조회하려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface BookmarkedPostListApiDoc {
+    }
+
+    /**
+     * 게시글 삭제 (soft delete)
+     */
+    @Operation(summary = "게시글 삭제", description = "게시글 작성자가 본인이 작성한 게시물을 삭제한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "삭제된 게시글의 pk를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "게시물을 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시물이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface DeletePostApiDoc {
+    }
+
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/common/controller/PostController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/common/controller/PostController.java
@@ -1,19 +1,13 @@
 package teamkiim.koffeechat.domain.post.common.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import teamkiim.koffeechat.domain.post.common.dto.response.BookmarkPostListResponse;
-import teamkiim.koffeechat.global.Auth;
 import teamkiim.koffeechat.domain.post.common.service.PostService;
+import teamkiim.koffeechat.global.Auth;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,25 +20,9 @@ public class PostController {
     /**
      * 좋아요
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/like/{postId}")
-    @Operation(summary = "게시글 좋아요", description = "사용자가 개발, 커뮤니티 게시판에 좋아요를 누른다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "게시물 좋아요 수를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 좋아요를 누르는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}"),
-                            @ExampleObject(name = "게시물을 찾을 수 없는 경우",
-                                    value = "{\"code\":404, \"message\":\"해당 게시물이 존재하지 않습니다\"}")}
-
-            ))
-    })
+    @PostApiDocument.LikeApiDoc
     public ResponseEntity<?> like(@PathVariable("postId") Long postId, HttpServletRequest request){
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -55,25 +33,9 @@ public class PostController {
     /**
      * 북마크
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/bookmark/{postId}")
-    @Operation(summary = "게시글 북마크", description = "사용자가 개발, 커뮤니티 게시판에 북마크를 누른다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "게시물 북마크 수를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 북마크를 누르는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}"),
-                            @ExampleObject(name = "게시물을 찾을 수 없는 경우",
-                                    value = "{\"code\":404, \"message\":\"해당 게시물이 존재하지 않습니다\"}")}
-
-            ))
-    })
+    @PostApiDocument.BookmarkApiDoc
     public ResponseEntity<?> bookmark(@PathVariable("postId") Long postId, HttpServletRequest request){
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -81,22 +43,14 @@ public class PostController {
         return postService.bookmark(memberId, postId);
     }
 
+    /**
+     * 북마크 리스트 확인
+     */
+    @AuthenticatedMemberPrincipal
     @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
             Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
     @GetMapping("/bookmark")
-    @Operation(summary = "사용자 북마크 게시물 리스트 조회", description = "로그인한 사용자의 북마크 게시물 리스트롤 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "북마크한 게시물 리스트를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = BookmarkPostListResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 북마크를 누르는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
+    @PostApiDocument.BookmarkedPostListApiDoc
     public ResponseEntity<?> findBookmarkedPostList(@RequestParam("page") int page, @RequestParam("size") int size,
                                                     HttpServletRequest request){
 
@@ -108,16 +62,9 @@ public class PostController {
     /**
      * 게시글 삭제 (soft delete)
      */
+    @AuthenticatedMemberPrincipal
     @DeleteMapping("delete/{postId}")
-    @Operation(summary = "게시글 삭제", description = "사용자가 작성한 게시물을 삭제한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 게시글의 PK를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "게시물을 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시물이 존재하지 않습니다\"}")}
-            ))
-    })
+    @PostApiDocument.DeletePostApiDoc
     public ResponseEntity<?> delete(@PathVariable("postId") Long postId){
 
         return postService.softDelete(postId);

--- a/src/main/java/teamkiim/koffeechat/domain/post/common/service/PostService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/common/service/PostService.java
@@ -3,6 +3,7 @@ package teamkiim.koffeechat.domain.post.common.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,7 +56,7 @@ public class PostService {
             post.addLike();
         }
 
-        return ResponseEntity.ok(post.getLikeCount());
+        return ResponseEntity.status(HttpStatus.CREATED).body(post.getLikeCount());
     }
 
     /**
@@ -81,7 +82,7 @@ public class PostService {
             post.addBookmark();
         }
 
-        return ResponseEntity.ok(post.getBookmarkCount());
+        return ResponseEntity.status(HttpStatus.CREATED).body(post.getBookmarkCount());
     }
 
     /**
@@ -122,7 +123,7 @@ public class PostService {
 
         post.delete();
 
-        return ResponseEntity.ok("게시글이 삭제되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(post.getId());
     }
 
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/CommunityPostApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/CommunityPostApiDocument.java
@@ -1,6 +1,15 @@
 package teamkiim.koffeechat.domain.post.community.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.post.common.dto.response.BookmarkPostListResponse;
+import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostListResponse;
+import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +20,124 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CommunityPostApiDocument {
+
+    /**
+     * 커뮤니티 게시글 최초 임시 저장
+     */
+    @Operation(summary = "게시글 최초 임시 저장", description = "사용자가 커뮤니티 게시판에 글을 작성할 때, 최초 임시 저장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성된 게시글의 PK를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface InitPostApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 작성 취소
+     */
+    @Operation(summary = "게시글 작성 취소", description = "사용자가 게시물을 작성하다가 취소하면 관련 도메인을 삭제한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 작성 취소 완료"),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "postId에 해당하는 게시물이 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CancelPostApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 작성
+     */
+    @Operation(summary = "게시글 저장", description = "사용자가 커뮤니티 게시판에 게시글을 저장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성된 게시글을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = CommunityPostResponse.class))),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "제목 없이 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":400, \"message\":\"제목을 입력해 주세요.\"}"),
+                            @ExampleObject(name = "본문 없이 게시글을 쓰려고 하는 경우",
+                                    value = "{\"code\":400, \"message\":\"내용을 입력해 주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "게시글 생성 시 최초 저장한 postId에 해당하는 게시물이 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SavePostApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 목록 조회
+     */
+    @Operation(summary = "게시글 목록 조회", description = "사용자가 커뮤니티 게시글 목록을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "커뮤니티 게시글 리스트를 반환한다. 만약 사진이 없으면 image 관련 필드는 null이 들어간다.",
+                    content = @Content(schema = @Schema(implementation = CommunityPostListResponse.class))),
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ShowListApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 상세 조회
+     */
+    @Operation(summary = "게시글 상세 조회", description = "사용자가 커뮤니티 게시글 단건을 상세 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "postId에 해당하는 커뮤니티 게시글을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = CommunityPostResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 상세 조회하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ShowPostApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 수정
+     */
+    @Operation(summary = "게시글 수정", description = "사용자가 커뮤니티 게시글을 수정한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "커뮤니티 게시글을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = CommunityPostResponse.class))),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "제목 없이 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":400, \"message\":\"제목을 입력해 주세요.\"}"),
+                            @ExampleObject(name = "본문 없이 게시글을 쓰려고 하는 경우",
+                                    value = "{\"code\":400, \"message\":\"내용을 입력해 주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "게시글을 수정하려는 회원에 대한 정보가 없는 경우",
+                            value = "{\"code\":404, \"message\":\"현재 로그인된 계정이 존재하지 않습니다.\"}"),
+                            @ExampleObject(name = "id에 해당하는 게시글이 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ModifyPostApiDoc {
+    }
+
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/CommunityPostController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/CommunityPostController.java
@@ -1,24 +1,16 @@
 package teamkiim.koffeechat.domain.post.community.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import teamkiim.koffeechat.domain.post.community.service.CommunityPostService;
-import teamkiim.koffeechat.global.Auth;
 import teamkiim.koffeechat.domain.post.community.controller.dto.ModifyCommunityPostRequest;
 import teamkiim.koffeechat.domain.post.community.controller.dto.SaveCommunityPostRequest;
-import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostListResponse;
-import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostResponse;
+import teamkiim.koffeechat.domain.post.community.service.CommunityPostService;
 import teamkiim.koffeechat.domain.vote.dto.request.SaveVoteServiceRequest;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,22 +23,9 @@ public class CommunityPostController {
     /**
      * 커뮤니티 게시글 최초 임시 저장
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/init")
-    @Operation(summary = "게시글 최초 임시 저장", description = "사용자가 커뮤니티 게시판에 글을 작성할 때, 최초 임시 저장한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 게시글의 PK를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
+    @CommunityPostApiDocument.InitPostApiDoc
     public ResponseEntity<?> initPost(HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -57,18 +36,10 @@ public class CommunityPostController {
     /**
      * 커뮤니티 게시글 작성 취소
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @DeleteMapping("/cancel/{postId}")
-    @Operation(summary = "게시글 작성 취소", description = "사용자가 게시물을 작성하다가 취소하면 관련 도메인을 삭제한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = ""),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "postId에 해당하는 게시물이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            ))
-    })
-    public ResponseEntity<?> cancelPost(@PathVariable("postId") Long postId) {
+    @CommunityPostApiDocument.CancelPostApiDoc
+    public ResponseEntity<?> CancelPostApiDoc(@PathVariable("postId") Long postId) {
 
         return communityPostService.cancelWriteCommunityPost(postId);
     }
@@ -76,22 +47,9 @@ public class CommunityPostController {
     /**
      * 커뮤니티 게시글 작성
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/post")
-    @Operation(summary = "게시글 저장", description = "사용자가 커뮤니티 게시판에 게시글을 저장한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 게시글을 반환한다.",
-                    content = @Content(schema = @Schema(implementation = CommunityPostResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "제목 or 본문 없이 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":400, \"message\":\"제목을 입력해 주세요.\"}")}
-            ))
-    })
+    @CommunityPostApiDocument.SavePostApiDoc
     public ResponseEntity<?> savePost(
             @Valid @RequestBody SaveCommunityPostRequest saveCommunityPostRequest, HttpServletRequest request) {
 
@@ -109,11 +67,7 @@ public class CommunityPostController {
      * 커뮤니티 게시글 목록 조회
      */
     @GetMapping("/list")
-    @Operation(summary = "게시글 목록 조회", description = "사용자가 커뮤니티 게시글 목록을 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "커뮤니티 게시글 리스트를 반환한다. 만약 사진이 없으면 image 관련 필드는 null이 들어간다.",
-                    content = @Content(schema = @Schema(implementation = CommunityPostListResponse.class))),
-    })
+    @CommunityPostApiDocument.ShowListApiDoc
     public ResponseEntity<?> showList(@RequestParam("page") int page, @RequestParam("size") int size) {
 
         return communityPostService.findCommunityPostList(page, size);
@@ -122,18 +76,9 @@ public class CommunityPostController {
     /**
      * 커뮤니티 게시글 상세 조회
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @GetMapping("/{postId}")
-    @Operation(summary = "게시글 상세 조회", description = "사용자가 커뮤니티 게시글 단건을 상세 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "커뮤니티 게시글을 반환한다.",
-                    content = @Content(schema = @Schema(implementation = CommunityPostResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            ))
-    })
+    @CommunityPostApiDocument.ShowPostApiDoc
     public ResponseEntity<?> showPost(@PathVariable("postId") Long postId, HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -144,18 +89,9 @@ public class CommunityPostController {
     /**
      * 커뮤니티 게시글 수정
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PatchMapping("/modify")
-    @Operation(summary = "게시글 수정", description = "사용자가 커뮤니티 게시글을 수정한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "커뮤니티 게시글을 반환한다.",
-                    content = @Content(schema = @Schema(implementation = CommunityPostResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "id에 해당하는 게시글이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            ))
-    })
+    @CommunityPostApiDocument.ModifyPostApiDoc
     public ResponseEntity<?> modifyPost(@Valid @RequestBody ModifyCommunityPostRequest modifyCommunityPostRequest,
                                         HttpServletRequest request) {
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/ModifyCommunityPostInfoRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/ModifyCommunityPostInfoRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.post.community.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,13 +9,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "커뮤니티 게시글 수정 Request")
 public class ModifyCommunityPostInfoRequest {
 
+    @Schema(description = "커뮤니티 게시글 pk", example = "1")
     private Long id;
 
+    @Schema(description = "커뮤니티 게시글 제목", example = "커뮤니티 게시글 제목입니다.")
     @NotBlank(message = "제목을 입력해주세요.")
     private String title;
 
+    @Schema(description = "커뮤니티 게시글 내용", example = "커뮤니티 게시글 내용입니다.")
     @NotBlank(message = "내용을 입력해주세요.")
     private String bodyContent;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/ModifyVoteRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/ModifyVoteRequest.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Schema(description = "커뮤니티 게시글 투표 수정 Request")
 public class ModifyVoteRequest {
 
-    @Schema(description = "투표 제목", example = "커뮤니티 게시글 투표 제목입니다.")
+    @Schema(description = "투표 제목", example = "커뮤니티 게시글 투표 제목 수정입니다.")
     @NotBlank(message = "투표 제목을 입력해 주세요.")
     private String title;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/ModifyVoteRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/ModifyVoteRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.post.community.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -13,11 +14,14 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "커뮤니티 게시글 투표 수정 Request")
 public class ModifyVoteRequest {
 
+    @Schema(description = "투표 제목", example = "커뮤니티 게시글 투표 제목입니다.")
     @NotBlank(message = "투표 제목을 입력해 주세요.")
     private String title;
 
+    @Schema(description = "투표 항목 리스트. 추가만 가능합니다.", example = "[\"항목 1\", \"항목 2\"]")
     @NotEmpty(message="항목을 입력해 주세요.")
     private List<String> items;
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/SaveCommunityPostInfoRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/SaveCommunityPostInfoRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.post.community.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,13 +11,17 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "커뮤니티 게시글 저장 Request")
 public class SaveCommunityPostInfoRequest {
 
+    @Schema(description = "커뮤니티 게시글 pk", example = "1")
     private Long id;
 
+    @Schema(description = "커뮤니티 게시글 제목", example = "커뮤니티 게시글 제목입니다.")
     @NotBlank(message = "제목을 입력해주세요.")
     private String title;
 
+    @Schema(description = "커뮤니티 게시글 내용", example = "커뮤니티 게시글 내용입니다.")
     @NotBlank(message = "내용을 입력해주세요.")
     private String bodyContent;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/SaveVoteRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/controller/dto/SaveVoteRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.post.community.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -13,11 +14,14 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "커뮤니티 게시글 투표 저장 Request")
 public class SaveVoteRequest {
 
+    @Schema(description = "투표 제목", example = "커뮤니티 게시글 투표 제목입니다.")
     @NotBlank(message = "투표 제목을 입력해 주세요.")
     private String title;
 
+    @Schema(description = "투표 항목 리스트", example = "[\"항목 1\", \"항목 2\"]")
     @NotEmpty(message="항목을 입력해 주세요.")
     private List<String> items;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/dto/response/VoteResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/dto/response/VoteResponse.java
@@ -28,6 +28,7 @@ public class VoteResponse {
         return VoteResponse.builder()
                 .title(vote.getTitle())
                 .voteItemResponseList(voteItemResponseList)
+                .isMemberVoted(isMemberVoted)
                 .build();
     }
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/community/service/CommunityPostService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/community/service/CommunityPostService.java
@@ -3,30 +3,31 @@ package teamkiim.koffeechat.domain.post.community.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamkiim.koffeechat.domain.bookmark.service.BookmarkService;
 import teamkiim.koffeechat.domain.file.service.FileService;
-import teamkiim.koffeechat.domain.postlike.service.PostLikeService;
-import teamkiim.koffeechat.global.exception.CustomException;
-import teamkiim.koffeechat.global.exception.ErrorCode;
 import teamkiim.koffeechat.domain.member.domain.Member;
 import teamkiim.koffeechat.domain.member.repository.MemberRepository;
 import teamkiim.koffeechat.domain.post.community.domain.CommunityPost;
-import teamkiim.koffeechat.domain.post.community.repository.CommunityPostRepository;
 import teamkiim.koffeechat.domain.post.community.dto.request.ModifyCommunityPostServiceRequest;
 import teamkiim.koffeechat.domain.post.community.dto.request.SaveCommunityPostServiceRequest;
 import teamkiim.koffeechat.domain.post.community.dto.response.CommentInfoDto;
 import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostListResponse;
 import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostResponse;
 import teamkiim.koffeechat.domain.post.community.dto.response.VoteResponse;
+import teamkiim.koffeechat.domain.post.community.repository.CommunityPostRepository;
 import teamkiim.koffeechat.domain.postlike.repository.PostLikeRepository;
+import teamkiim.koffeechat.domain.postlike.service.PostLikeService;
 import teamkiim.koffeechat.domain.vote.domain.Vote;
-import teamkiim.koffeechat.domain.vote.repository.VoteRepository;
-import teamkiim.koffeechat.domain.vote.service.VoteService;
 import teamkiim.koffeechat.domain.vote.dto.request.ModifyVoteServiceRequest;
 import teamkiim.koffeechat.domain.vote.dto.request.SaveVoteServiceRequest;
+import teamkiim.koffeechat.domain.vote.repository.VoteRepository;
+import teamkiim.koffeechat.domain.vote.service.VoteService;
+import teamkiim.koffeechat.global.exception.CustomException;
+import teamkiim.koffeechat.global.exception.ErrorCode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,7 @@ public class CommunityPostService {
 
     /**
      * 게시글 최초 임시 저장
+     *
      * @param memberId 작성자 PK
      * @return Long 게시글 PK
      */
@@ -65,11 +67,12 @@ public class CommunityPostService {
 
         CommunityPost saveCommunityPost = communityPostRepository.save(communityPost);
 
-        return ResponseEntity.ok(saveCommunityPost.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(saveCommunityPost.getId());
     }
 
     /**
      * 커뮤니티 게시글 작성 취소
+     *
      * @param postId 게시글 PK
      * @return ok
      */
@@ -83,13 +86,14 @@ public class CommunityPostService {
 
         communityPostRepository.delete(communityPost);
 
-        return ResponseEntity.ok("게시글 삭제 완료");
+        return ResponseEntity.ok("게시글 작성 취소 완료");
     }
 
     /**
      * 게시글 저장
+     *
      * @param saveCommunityPostServiceRequest 게시글 저장 dto
-     * @return CommunityPostResponse
+     * @return CommunityPostResponse HttpStatus created
      */
     @Transactional
     public ResponseEntity<?> saveCommunityPost(SaveCommunityPostServiceRequest saveCommunityPostServiceRequest,
@@ -108,16 +112,20 @@ public class CommunityPostService {
         List<CommentInfoDto> commentInfoDtoList = new ArrayList<>();
 
         if (saveVoteServiceRequest == null) {  //투표 x
-            return ResponseEntity.ok(CommunityPostResponse.of(communityPost, commentInfoDtoList, null, memberId, false, false));
-            }
+            return ResponseEntity.status(HttpStatus.CREATED).body(CommunityPostResponse.of(communityPost, commentInfoDtoList, null, memberId, false, false));
+
+        }
 
         //투표 o
         Vote savedVote = voteService.saveVote(saveVoteServiceRequest, saveCommunityPostServiceRequest.getId());  //투표 저장
-        return ResponseEntity.ok(CommunityPostResponse.of(communityPost, commentInfoDtoList, VoteResponse.of(savedVote, true), memberId, false, false));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommunityPostResponse.of(communityPost, commentInfoDtoList, VoteResponse.of(savedVote, true), memberId, false, false));
+
     }
 
     /**
      * 게시글 목록 조회
+     *
      * @param page 페이지 번호 ( ex) 0, 1,,,, )
      * @param size 페이지 당 조회할 데이터 수
      * @return List<CommunityPostListResponse>
@@ -136,6 +144,7 @@ public class CommunityPostService {
 
     /**
      * 게시글 상세 조회
+     *
      * @param postId postId 게시글 PK
      * @return CommunityPostResponse
      */
@@ -156,8 +165,7 @@ public class CommunityPostService {
         if (vote.isPresent()) {
             boolean isMemberVoted = voteService.hasMemberVoted(vote.get(), member);
             voteResponse = VoteResponse.of(vote.get(), isMemberVoted);
-        }
-        else voteResponse = null;
+        } else voteResponse = null;
 
         boolean isMemberBookmarked = bookmarkService.isMemberBookmarked(member, communityPost);
 
@@ -166,6 +174,7 @@ public class CommunityPostService {
 
     /**
      * 게시글 수정
+     *
      * @param modifyCommunityPostServiceRequest 게시글 수정 dto
      * @return CommunityPostResponse
      */
@@ -205,6 +214,6 @@ public class CommunityPostService {
 
         boolean isMemberBookmarked = bookmarkService.isMemberBookmarked(member, communityPost);
 
-        return ResponseEntity.ok(CommunityPostResponse.of(communityPost, commentInfoDtoList, voteResponse, memberId, isMemberLiked, isMemberBookmarked));
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommunityPostResponse.of(communityPost, commentInfoDtoList, voteResponse, memberId, isMemberLiked, isMemberBookmarked));
     }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/DevPostApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/DevPostApiDocument.java
@@ -1,6 +1,16 @@
 package teamkiim.koffeechat.domain.post.dev.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostListResponse;
+import teamkiim.koffeechat.domain.post.community.dto.response.CommunityPostResponse;
+import teamkiim.koffeechat.domain.post.dev.dto.response.DevPostListResponse;
+import teamkiim.koffeechat.domain.post.dev.dto.response.DevPostResponse;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +21,124 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DevPostApiDocument {
+
+
+    /**
+     * 개발 게시글 최초 임시 저장
+     */
+    @Operation(summary = "게시글 최초 임시 저장", description = "사용자가 개발 게시판에 글을 작성할 때, 최초 임시 저장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성된 게시글의 PK를 반환한다.",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface InitPostApiDoc {
+    }
+
+    /**
+     * 개발 게시글 작성 취소
+     */
+    @Operation(summary = "게시글 작성 취소", description = "사용자가 게시물을 작성하다가 취소하면 관련 도메인을 삭제한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 작성 취소 완료"),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "postId에 해당하는 게시물이 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CancelPostApiDoc {
+    }
+
+    /**
+     * 개발 게시글 작성
+     */
+    @Operation(summary = "게시글 저장", description = "사용자가 개발 게시판에 게시글을 저장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성된 게시글을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = DevPostResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "제목 없이 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":400, \"message\":\"제목을 입력해 주세요.\"}"),
+                            @ExampleObject(name = "본문 없이 게시글을 쓰려고 하는 경우",
+                                    value = "{\"code\":400, \"message\":\"내용을 입력해 주세요.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SavePostApiDoc {
+    }
+
+    /**
+     * 개발 게시글 목록 조회
+     */
+    @Operation(summary = "게시글 목록 조회", description = "사용자가 개발 게시글 목록을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "개발 게시글 리스트를 반환한다. 만약 사진이 없으면 image 관련 필드는 null이 들어간다.",
+                    content = @Content(schema = @Schema(implementation = DevPostListResponse.class))),
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ShowListApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 상세 조회
+     */
+    @Operation(summary = "게시글 상세 조회", description = "사용자가 개발 게시글 단건을 상세 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "개발 게시글을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = DevPostResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 상세 조회하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
+                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ShowPostApiDoc {
+    }
+
+    /**
+     * 커뮤니티 게시글 수정
+     */
+    @Operation(summary = "게시글 수정", description = "사용자가 개발 게시글을 수정한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "개발 게시글을 반환한다.",
+                    content = @Content(schema = @Schema(implementation = DevPostResponse.class))),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "제목 없이 게시글을 쓰려고 하는 경우",
+                            value = "{\"code\":400, \"message\":\"제목을 입력해 주세요.\"}"),
+                            @ExampleObject(name = "본문 없이 게시글을 쓰려고 하는 경우",
+                                    value = "{\"code\":400, \"message\":\"내용을 입력해 주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "게시글을 수정하려는 회원에 대한 정보가 없는 경우",
+                            value = "{\"code\":404, \"message\":\"현재 로그인된 계정이 존재하지 않습니다.\"}"),
+                            @ExampleObject(name = "id에 해당하는 게시글이 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
+            ))
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ModifyPostApiDoc {
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/DevPostController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/DevPostController.java
@@ -20,6 +20,7 @@ import teamkiim.koffeechat.domain.post.dev.controller.dto.SaveDevPostRequest;
 import teamkiim.koffeechat.domain.post.dev.domain.ChildSkillCategory;
 import teamkiim.koffeechat.domain.post.dev.dto.response.DevPostListResponse;
 import teamkiim.koffeechat.domain.post.dev.service.DevPostService;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 import java.util.List;
 
@@ -35,22 +36,9 @@ public class DevPostController {
     /**
      * 개발 게시글 최초 임시 저장
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/init")
-    @Operation(summary = "게시글 최초 임시 저장", description = "사용자가 개발 게시판에 글을 작성할 때, 최초 임시 저장한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 게시글의 PK를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = Long.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다\"}")}
-            ))
-    })
+    @DevPostApiDocument.InitPostApiDoc
     public ResponseEntity<?> initPost(HttpServletRequest request){
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -61,17 +49,9 @@ public class DevPostController {
     /**
      * 개발 게시글 작성 취소
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @DeleteMapping("/cancel/{postId}")
-    @Operation(summary = "게시글 작성 취소", description = "사용자가 게시물을 작성하다가 취소하면 관련 도메인을 삭제한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = ""),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "postId에 해당하는 게시물이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            ))
-    })
+    @DevPostApiDocument.CancelPostApiDoc
     public ResponseEntity<?> cancelPost(@PathVariable("postId") Long postId){
 
         return devPostService.cancelWriteDevPost(postId);
@@ -80,22 +60,9 @@ public class DevPostController {
     /**
      * 개발 게시글 작성
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/post")
-    @Operation(summary = "게시글 저장", description = "사용자가 개발 게시판에 게시글을 저장한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성된 게시글을 반환한다.",
-                    content = @Content(schema = @Schema(implementation = DevPostResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
-            )),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "제목 or 본문 없이 게시글을 쓰려고 하는 경우",
-                            value = "{\"code\":400, \"message\":\"제목을 입력해 주세요.\"}")}
-            ))
-    })
+    @DevPostApiDocument.SavePostApiDoc
     public ResponseEntity<?> savePost(@Valid @RequestBody SaveDevPostRequest saveDevPostRequest, HttpServletRequest request) {
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -107,11 +74,7 @@ public class DevPostController {
      * 개발 게시글 목록 조회
      */
     @GetMapping("/list")
-    @Operation(summary = "게시글 목록 조회", description = "사용자가 개발 게시글 목록을 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "개발 게시글 리스트를 반환한다. 만약 사진이 없으면 image 관련 필드는 null이 들어간다.",
-                    content = @Content(schema = @Schema(implementation = DevPostListResponse.class))),
-    })
+    @DevPostApiDocument.ShowListApiDoc
     public ResponseEntity<?> showList(@RequestParam("page") int page, @RequestParam("size") int size,
                                       @RequestParam(value = "skillCategory", required = false) List<ChildSkillCategory> childSkillCategoryList){
 
@@ -123,18 +86,9 @@ public class DevPostController {
     /**
      * 개발 게시글 상세 조회
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @GetMapping("/{postId}")
-    @Operation(summary = "게시글 상세 조회", description = "사용자가 개발 게시글 단건을 상세 조회한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "개발 게시글을 반환한다.",
-                    content = @Content(schema = @Schema(implementation = DevPostResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            ))
-    })
+    @DevPostApiDocument.ShowPostApiDoc
     public ResponseEntity<?> showPost(@PathVariable("postId") Long postId, HttpServletRequest request){
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));
@@ -145,18 +99,9 @@ public class DevPostController {
     /**
      * 개발 게시글 수정
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PatchMapping("/modify")
-    @Operation(summary = "게시글 수정", description = "사용자가 개발 게시글을 수정한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "개발 게시글을 반환한다.",
-                    content = @Content(schema = @Schema(implementation = DevPostResponse.class))),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {@ExampleObject(name = "id에 해당하는 게시글이 없는 경우",
-                            value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")}
-            ))
-    })
+    @DevPostApiDocument.ModifyPostApiDoc
     public ResponseEntity<?> modifyPost(@Valid @RequestBody ModifyDevPostRequest modifyDevPostRequest, HttpServletRequest request){
 
         Long memberId = Long.valueOf(String.valueOf(request.getAttribute("authenticatedMemberPK")));

--- a/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/dto/ModifyDevPostRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/dto/ModifyDevPostRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.post.dev.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,13 +14,21 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "개발 게시글 수정 Request")
 public class ModifyDevPostRequest {
 
+    @Schema(description = "수정할 개발 게시글 pk")
     private Long id;
+
+    @Schema(description = "개발 게시글 제목", example="개발 게시글 제목입니다.")
     @NotBlank(message = "제목을 입력해주세요.")
     private String title;
+
+    @Schema(description = "개발 게시글 내용", example="개발 게시글 내용입니다.")
     @NotBlank(message = "내용을 입력해주세요.")
     private String bodyContent;
+
+    @Schema(description = "개발 게시글 연관 카테고리")
     private List<ParentSkillCategory> parentSkillCategoryList;
     private List<ChildSkillCategory> childSkillCategoryList;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/dto/ModifyDevPostRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/dto/ModifyDevPostRequest.java
@@ -20,11 +20,11 @@ public class ModifyDevPostRequest {
     @Schema(description = "수정할 개발 게시글 pk")
     private Long id;
 
-    @Schema(description = "개발 게시글 제목", example="개발 게시글 제목입니다.")
+    @Schema(description = "개발 게시글 제목", example="개발 게시글 제목 수정입니다.")
     @NotBlank(message = "제목을 입력해주세요.")
     private String title;
 
-    @Schema(description = "개발 게시글 내용", example="개발 게시글 내용입니다.")
+    @Schema(description = "개발 게시글 내용", example="개발 게시글 내용 수정입니다.")
     @NotBlank(message = "내용을 입력해주세요.")
     private String bodyContent;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/dto/SaveDevPostRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/dev/controller/dto/SaveDevPostRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.post.dev.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,13 +13,21 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "개발 게시글 저장 Request")
 public class SaveDevPostRequest {
 
+    @Schema(description = "최초 저장한 게시글 pk", example = "1")
     private Long id;
+
+    @Schema(description = "개발 게시글 제목" , example = "개발 게시글 제목입니다.")
     @NotBlank(message = "제목을 입력해주세요.")
     private String title;
+
+    @Schema(description = "개발 게시글 내용" , example = "개발 게시글 내용입니다.")
     @NotBlank(message = "내용을 입력해주세요.")
     private String bodyContent;
+
+    @Schema(description = "게시글 관련 기술 카테고리")
     private List<SkillCategory> skillCategoryList;
     private List<Long> fileIdList;
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/dev/service/DevPostService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/dev/service/DevPostService.java
@@ -3,6 +3,7 @@ package teamkiim.koffeechat.domain.post.dev.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +59,7 @@ public class DevPostService {
 
         DevPost saveDevPost = devPostRepository.save(devPost);
 
-        return ResponseEntity.ok(saveDevPost.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(saveDevPost.getId());
     }
 
     /**
@@ -95,7 +96,7 @@ public class DevPostService {
 
         fileService.deleteImageFiles(saveDevPostServiceRequest.getFileIdList(), devPost);
 
-        return ResponseEntity.ok(DevPostResponse.of(devPost, memberId, false, false));
+        return ResponseEntity.status(HttpStatus.CREATED).body(DevPostResponse.of(devPost, memberId, false, false));
     }
 
     /**
@@ -165,7 +166,7 @@ public class DevPostService {
 
         boolean isMemberBookmarked = bookmarkService.isMemberBookmarked(member, devPost);
 
-        return ResponseEntity.ok(DevPostResponse.of(devPost, memberId, isMemberLiked,isMemberBookmarked ));
+        return ResponseEntity.status(HttpStatus.CREATED).body(DevPostResponse.of(devPost, memberId, isMemberLiked,isMemberBookmarked ));
     }
 
 

--- a/src/main/java/teamkiim/koffeechat/domain/vote/controller/VoteApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/vote/controller/VoteApiDocument.java
@@ -1,6 +1,13 @@
 package teamkiim.koffeechat.domain.vote.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,4 +18,30 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface VoteApiDocument {
+
+    /**
+     * 투표
+     */
+    @Operation(summary = "투표", description = "사용자가 커뮤니티 게시글 투표 항목에 투표한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "투표 완료"),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "로그인하지 않은 사용자가 프로필 사진을 등록하려고 하는 경우",
+                            value = "{\"code\":401, \"message\":\"로그인해주세요.\"}")}
+            )),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(name = "사용자를 찾을 수 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다.\"}"),
+                            @ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}"),
+                            @ExampleObject(name = "post에 투표가 없는 경우",
+                                    value = "{\"code\":404, \"message\":\"해당 투표가 존재하지 않습니다.\"}")
+                    })
+            )
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SaveVoteRecord {
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/vote/controller/VoteController.java
+++ b/src/main/java/teamkiim/koffeechat/domain/vote/controller/VoteController.java
@@ -1,19 +1,14 @@
 package teamkiim.koffeechat.domain.vote.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import teamkiim.koffeechat.global.Auth;
 import teamkiim.koffeechat.domain.vote.controller.dto.SaveVoteRecordRequest;
 import teamkiim.koffeechat.domain.vote.service.VoteService;
+import teamkiim.koffeechat.global.AuthenticatedMemberPrincipal;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,25 +18,12 @@ public class VoteController {
 
     private final VoteService voteService;
 
-
     /**
      * 투표
      */
-    @Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
-            Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
+    @AuthenticatedMemberPrincipal
     @PostMapping("/{postId}/votes")
-    @Operation(summary = "투표", description = "사용자가 커뮤니티 게시글 투표 항목에 투표한다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "투표 완료"),
-            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
-                    examples = {
-                            @ExampleObject(name = "사용자를 찾을 수 없는 경우",
-                                    value = "{\"code\":404, \"message\":\"해당 회원이 존재하지 않습니다.\"}"),
-                            @ExampleObject(name = "postId에 해당하는 게시글이 없는 경우",
-                                    value = "{\"code\":404, \"message\":\"해당 게시글이 존재하지 않습니다.\"}")
-                    })
-            )
-    })
+    @VoteApiDocument.SaveVoteRecord
     public ResponseEntity<?> saveVoteRecord(@PathVariable("postId") Long postId,
                                             @Valid @RequestBody SaveVoteRecordRequest saveVoteRecordRequest, HttpServletRequest request){
 

--- a/src/main/java/teamkiim/koffeechat/domain/vote/controller/dto/SaveVoteRecordRequest.java
+++ b/src/main/java/teamkiim/koffeechat/domain/vote/controller/dto/SaveVoteRecordRequest.java
@@ -1,5 +1,6 @@
 package teamkiim.koffeechat.domain.vote.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,9 +13,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "커뮤니티 게시글 투표 Request")
 public class SaveVoteRecordRequest {
 
-    @NotEmpty(message="투표할 항목을 선택해 주세요.")
+    @Schema(description = "사용자가 투표한 투표 항목 pk list", example ="[1, 2]")
     private List<Long> items;
 
 }

--- a/src/main/java/teamkiim/koffeechat/domain/vote/service/VoteService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/vote/service/VoteService.java
@@ -2,13 +2,9 @@ package teamkiim.koffeechat.domain.vote.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamkiim.koffeechat.domain.vote.repository.VoteItemRepository;
-import teamkiim.koffeechat.global.exception.CustomException;
-import teamkiim.koffeechat.global.exception.ErrorCode;
 import teamkiim.koffeechat.domain.member.domain.Member;
 import teamkiim.koffeechat.domain.member.repository.MemberRepository;
 import teamkiim.koffeechat.domain.post.common.domain.Post;
@@ -17,11 +13,14 @@ import teamkiim.koffeechat.domain.vote.controller.dto.SaveVoteRecordRequest;
 import teamkiim.koffeechat.domain.vote.domain.Vote;
 import teamkiim.koffeechat.domain.vote.domain.VoteItem;
 import teamkiim.koffeechat.domain.vote.domain.VoteRecord;
-import teamkiim.koffeechat.domain.vote.repository.VoteRecordRepository;
-import teamkiim.koffeechat.domain.vote.repository.VoteRepository;
 import teamkiim.koffeechat.domain.vote.dto.SaveVoteRecordServiceDto;
 import teamkiim.koffeechat.domain.vote.dto.request.ModifyVoteServiceRequest;
 import teamkiim.koffeechat.domain.vote.dto.request.SaveVoteServiceRequest;
+import teamkiim.koffeechat.domain.vote.repository.VoteItemRepository;
+import teamkiim.koffeechat.domain.vote.repository.VoteRecordRepository;
+import teamkiim.koffeechat.domain.vote.repository.VoteRepository;
+import teamkiim.koffeechat.global.exception.CustomException;
+import teamkiim.koffeechat.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -63,9 +62,7 @@ public class VoteService {
         Vote vote = saveVoteServiceRequest.toEntity(post, saveVoteServiceRequest.getTitle());  //투표 생성
         Vote savedVote = voteRepository.save(vote);
 
-        for (VoteItem voteItem : vote.getVoteItems()) {
-            voteItemRepository.save(voteItem);
-        }
+        voteItemRepository.saveAll(vote.getVoteItems());
 
         return savedVote;
     }
@@ -115,6 +112,10 @@ public class VoteService {
 
         List<VoteItem> voteItemList = voteItemRepository.findAllByPostAndIds(post, saveVoteRecordRequest.getItems());  //투표한 항목 존재 여부 확인
 
+        if (!saveVoteRecordRequest.getItems().isEmpty() && voteItemList.isEmpty()) {
+            throw new CustomException(ErrorCode.VOTE_ITEM_NOT_FOUND);
+        }
+
         List<VoteRecord> voteRecordList = voteRecordRepository.findByVoteAndMember(vote, member);  //기존 투표 기록
         if (!voteRecordList.isEmpty()) { //기존 투표 기록 삭제
             for (VoteRecord voteRecord : voteRecordList) {
@@ -125,10 +126,12 @@ public class VoteService {
             voteRecordRepository.deleteAll(voteRecordList);
         }
 
-        if (voteItemList.isEmpty()) return ResponseEntity.status(HttpStatus.CREATED).body("투표 완료");
+        //모두 투표 취소한 경우
+//        if (saveVoteRecordRequest.getItems().isEmpty()) return ResponseEntity.status(HttpStatus.CREATED).body("투표 기록 초기화");
 
-        if (!voteItemList.isEmpty()) { //재투표 항목에 대한 투표 기록
-            for (VoteItem votedItem : voteItemList) {  //투표 항목들에 대해 투표 기록 생성
+        //재투표 항목들에 대해 투표 기록 생성
+        if (!saveVoteRecordRequest.getItems().isEmpty()) {
+            for (VoteItem votedItem : voteItemList) {
                 VoteRecord voteRecord = VoteRecord.create(member, votedItem);
                 VoteRecord saveVoteRecord = voteRecordRepository.save(voteRecord);
                 votedItem.addVoteRecord(saveVoteRecord);  //연관관계 주입

--- a/src/main/java/teamkiim/koffeechat/global/Auth.java
+++ b/src/main/java/teamkiim/koffeechat/global/Auth.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Auth {
 

--- a/src/main/java/teamkiim/koffeechat/global/AuthenticatedMemberPrincipal.java
+++ b/src/main/java/teamkiim/koffeechat/global/AuthenticatedMemberPrincipal.java
@@ -5,7 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.PARAMETER)
+/**
+ * 회원 권한 확인
+ * {COMPANY_EMPLOYEE, FREELANCER, STUDENT, COMPANY_EMPLOYEE_TEMP, MANAGER, ADMIN}
+ */
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Auth(role = {Auth.MemberRole.COMPANY_EMPLOYEE, Auth.MemberRole.FREELANCER, Auth.MemberRole.STUDENT,
+        Auth.MemberRole.COMPANY_EMPLOYEE_TEMP, Auth.MemberRole.MANAGER, Auth.MemberRole.ADMIN})
 public @interface AuthenticatedMemberPrincipal {
 }

--- a/src/main/java/teamkiim/koffeechat/global/exception/ErrorCode.java
+++ b/src/main/java/teamkiim/koffeechat/global/exception/ErrorCode.java
@@ -35,11 +35,13 @@ public enum ErrorCode {
     MEMBER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER FOLLOW가 존재하지 않습니다."),
     VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "투표가 존재하지 않습니다."),
     VOTE_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND,"투표 항목이 존재하지 않습니다."),
+    CORP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회사 도메인이 존재하지 않습니다."),
 
     // 409 CONFLICT
     EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 회원가입된 이메일입니다."),
     CHAT_ROOM_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 채팅방이 존재합니다."),
     VOTE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 투표되었습니다."),
+    CORP_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사 도메인입니다."),
 
     // 500 INTERNAL_SERVER_ERROR
     JSON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 사용자 정보 json 파싱 에러"),

--- a/src/main/java/teamkiim/koffeechat/global/exception/ErrorCode.java
+++ b/src/main/java/teamkiim/koffeechat/global/exception/ErrorCode.java
@@ -22,9 +22,7 @@ public enum ErrorCode {
 
     // 403 FORBIDDEN
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 회원에 권한이 없습니다."),
-    UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN,"게시글 수정 권한이 없습니다."),
-    DELETE_FORBIDDEN(HttpStatus.FORBIDDEN,"게시글 삭제 권한이 없습니다."),
-    VOTE_FORBIDDEN(HttpStatus.FORBIDDEN, "투표 생성 권한이 없습니다."),
+    VOTE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 회원에 투표 생성 권한이 없습니다."),
 
     // 404 NOT FOUND
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다."),

--- a/src/main/java/teamkiim/koffeechat/global/swagger/config/SwaggerConfig.java
+++ b/src/main/java/teamkiim/koffeechat/global/swagger/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ public class SwaggerConfig {
     public OpenAPI openAPI(){
 
         Info info = new Info()
-                .title("KoffeChat API Document")
+                .title("KoffeeChat API Document")
                 .description("CBNU SW 졸업작품 KoffeeChat 프로젝트의 API 명세서");
 
         return new OpenAPI()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

> 게시글과 관련없는 투표 항목에 투표 시 404 에러 처리

 : 게시글과 관련없는 투표 항목에 투표하는 경우에도 200 ok 가 반환되고, 아무 작동하지 않아서 404 에러 처리로 수정했습니다.

> 사용자가 게시글을 확인했을 때 항상 isVoted=false인 오류 수정

 : 투표한 회원이 게시글을 확인했을 때에도 해당 회원이 투표한 기록이 보이지 않는 문제가 있어 수정했습니다.

> 요구사항 변경
재투표 버튼을 누르고 사용자 지정 재투표
-> 재투표 버튼을 누르면 해당 회원의 투표 정보 reset 후 재투표

: 재투표 버튼을 눌렀을때 회원의 투표 정보가 reset 된 후 재투표 하는 것이 사용자 입장에서 쓰기 편할 것 같아 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- 새로운 기능 추가
- 버그 수정

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
.
