### PR TITLE
fix : 게시글 관련 에러 수정

### DIFF
--- a/src/main/java/teamkiim/koffeechat/domain/file/service/s3/S3PostFileService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/file/service/s3/S3PostFileService.java
@@ -96,7 +96,7 @@ public class S3PostFileService implements PostFileService {
             log.info("deleteFileUrl : {}", url);
         }
 
-        if (!(urls.isEmpty())) {
+        if (urls.isEmpty()) {
             return;
         }
 

--- a/src/main/java/teamkiim/koffeechat/domain/post/common/dto/response/BookmarkPostListResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/common/dto/response/BookmarkPostListResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import teamkiim.koffeechat.domain.file.domain.File;
 import teamkiim.koffeechat.domain.post.common.domain.Post;
 
 @Getter
@@ -15,7 +16,7 @@ import teamkiim.koffeechat.domain.post.common.domain.Post;
 @Schema(description = "회원이 북마크한 게시글 리스트 Response")
 public class BookmarkPostListResponse {
 
-    private String id;                                // PK
+    private String id;                              // PK
     private String title;                           // 제목
     private String bodyContent;                     // 본문
     private long viewCount;                         // 조회수
@@ -24,13 +25,11 @@ public class BookmarkPostListResponse {
     private LocalDateTime createdTime;              // 작성 시간
     private LocalDateTime modifiedTime;             // 수정 시간
     private String nickname;                        // 작성자 닉네임
-    private String profileImageUrl;
-
-    private String imagePath;                       // 이미지 경로
-    private String imageName;                       // 이미지 이름
+    private String profileImageUrl;                 // 작성자 프로필 이미지 경로
+    private String contentImageUrl;                 // 게시글에 포함된 이미지 url
 
     public static BookmarkPostListResponse of(String postId, Post post) {
-        return BookmarkPostListResponse.builder()
+        BookmarkPostListResponse response = BookmarkPostListResponse.builder()
                 .id(postId)
                 .title(post.getTitle())
                 .bodyContent(post.getBodyContent())
@@ -40,9 +39,18 @@ public class BookmarkPostListResponse {
                 .createdTime(post.getCreatedTime())
                 .nickname(post.getMember().getNickname())
                 .profileImageUrl(post.getMember().getProfileImageUrl())
-                .imagePath(null)
-                .imageName(null)
+                .contentImageUrl(null)
                 .build();
+
+        if (!post.getFileList().isEmpty()) {
+            response.setImageInfo(post.getFileList().get(0));
+        }
+
+        return response;
     }
 
+    private void setImageInfo(File file) {
+
+        this.contentImageUrl = file.getUrl();
+    }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/common/dto/response/MyPostListResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/common/dto/response/MyPostListResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import teamkiim.koffeechat.domain.file.domain.File;
 import teamkiim.koffeechat.domain.post.common.domain.Post;
 
 @Getter
@@ -24,13 +25,12 @@ public class MyPostListResponse {
     private LocalDateTime createdTime;              // 작성 시간
     private LocalDateTime modifiedTime;             // 수정 시간
     private String nickname;                        // 작성자 닉네임
-    private String profileImageUrl;
-
-    private String imagePath;                       // 이미지 경로
-    private String imageName;                       // 이미지 이름
+    private String profileImageUrl;                 // 작성자 프로필 이미지 경로
+    private String contentImageUrl;                 // 게시글에 포함된 이미지 url
 
     public static MyPostListResponse of(String postId, Post post) {
-        return MyPostListResponse.builder()
+
+        MyPostListResponse response = MyPostListResponse.builder()
                 .id(postId)
                 .title(post.getTitle())
                 .bodyContent(post.getBodyContent())
@@ -40,8 +40,18 @@ public class MyPostListResponse {
                 .createdTime(post.getCreatedTime())
                 .nickname(post.getMember().getNickname())
                 .profileImageUrl(post.getMember().getProfileImageUrl())
-                .imagePath(null)
-                .imageName(null)
+                .contentImageUrl(null)
                 .build();
+
+        if (!post.getFileList().isEmpty()) {
+            response.setImageInfo(post.getFileList().get(0));
+        }
+
+        return response;
+    }
+
+    private void setImageInfo(File file) {
+
+        this.contentImageUrl = file.getUrl();
     }
 }

--- a/src/main/java/teamkiim/koffeechat/domain/post/common/service/PostService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/post/common/service/PostService.java
@@ -150,7 +150,7 @@ public class PostService {
      * @param sortType     정렬 순서 (최신순, 좋아요순, 조회순)
      * @param page         페이지 번호 ( ex) 0, 1,,,, )
      * @param size         페이지 당 조회할 데이터 수
-     * @return List<BookmarkPostListResponse>
+     * @return List<MyPostListResponse>
      */
     public List<MyPostListResponse> findMyPostList(Long memberId, PostCategory postCategory, SortType sortType,
                                                    int page, int size) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> -마이페이지 게시글 조회 시 이미지 경로 dto에 추가
- 게시글 작성 시, 파일 저장하지 않고 작성이 안되는 에러 처리

## PR 유형
어떤 변경 사항이 있나요?

- 버그 수정
- 코드 리팩토링

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
