### PR TITLE
fix : 기술 채팅방 목록 조회 시, 상대방 회원이 조회 안되는 버그 수정

### DIFF
--- a/src/main/java/teamkiim/koffeechat/domain/chat/room/direct/controller/DirectChatRoomApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/chat/room/direct/controller/DirectChatRoomApiDocument.java
@@ -11,8 +11,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import teamkiim.koffeechat.domain.chat.room.common.dto.response.ChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.direct.dto.response.CreateDirectChatRoomResponse;
+import teamkiim.koffeechat.domain.chat.room.direct.dto.response.DirectChatRoomListResponse;
 
 @Tag(name = "DIRECT(일대일) 채팅방 API")
 @Target(ElementType.METHOD)
@@ -40,7 +40,7 @@ public @interface DirectChatRoomApiDocument {
     @Operation(summary = "현재 참여중인 채팅방 목록 페이징 조회", description = "사용자가 현재 참여중인 채팅방의 목록을 페이징해 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원이 현재 속한 채팅방 정보 리스트를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = ChatRoomListResponse.class))),
+                    content = @Content(schema = @Schema(implementation = DirectChatRoomListResponse.class))),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
                     examples = {@ExampleObject(name = "회원을 찾을 수 없는 경우")})),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",

--- a/src/main/java/teamkiim/koffeechat/domain/chat/room/direct/dto/response/DirectChatRoomListResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/chat/room/direct/dto/response/DirectChatRoomListResponse.java
@@ -1,4 +1,4 @@
-package teamkiim.koffeechat.domain.chat.room.common.dto.response;
+package teamkiim.koffeechat.domain.chat.room.direct.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -13,7 +13,7 @@ import teamkiim.koffeechat.domain.member.domain.Member;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatRoomListResponse {
+public class DirectChatRoomListResponse {
 
     private String memberId;
     private String chatRoomId;
@@ -25,8 +25,8 @@ public class ChatRoomListResponse {
     private String oppositeMemberId;
     private String profileImageUrl;
 
-    public static ChatRoomListResponse of(String memberId, String chatRoomId, String oppositeMemberId,
-                                          Member oppositeMember, ChatRoomInfoDto chatRoomInfo) {
+    public static DirectChatRoomListResponse of(String memberId, String chatRoomId, String oppositeMemberId,
+                                                Member oppositeMember, ChatRoomInfoDto chatRoomInfo) {
 
         String roomName = chatRoomInfo.getMemberChatRoom().getChatRoom().getName();
 
@@ -34,7 +34,7 @@ public class ChatRoomListResponse {
             roomName = oppositeMember.getNickname();
         }
 
-        return ChatRoomListResponse.builder()
+        return DirectChatRoomListResponse.builder()
                 .memberId(memberId)
                 .chatRoomId(chatRoomId)
                 .chatRoomType(chatRoomInfo.getMemberChatRoom().getChatRoom().getChatRoomType())

--- a/src/main/java/teamkiim/koffeechat/domain/chat/room/direct/service/DirectChatRoomService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/chat/room/direct/service/DirectChatRoomService.java
@@ -18,10 +18,10 @@ import teamkiim.koffeechat.domain.chat.room.common.domain.ChatRoom;
 import teamkiim.koffeechat.domain.chat.room.common.domain.ChatRoomType;
 import teamkiim.koffeechat.domain.chat.room.common.domain.MemberChatRoom;
 import teamkiim.koffeechat.domain.chat.room.common.dto.ChatRoomInfoDto;
-import teamkiim.koffeechat.domain.chat.room.common.dto.response.ChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.common.repository.MemberChatRoomRepository;
 import teamkiim.koffeechat.domain.chat.room.direct.domain.DirectChatRoom;
 import teamkiim.koffeechat.domain.chat.room.direct.dto.response.CreateDirectChatRoomResponse;
+import teamkiim.koffeechat.domain.chat.room.direct.dto.response.DirectChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.direct.repository.DirectChatRoomRepository;
 import teamkiim.koffeechat.domain.member.domain.Member;
 import teamkiim.koffeechat.domain.member.repository.MemberRepository;
@@ -129,7 +129,7 @@ public class DirectChatRoomService {
      * @param size     페이징에 사용될 size
      * @return List<ChatRoomListResponse>
      */
-    public List<ChatRoomListResponse> findChatRoomList(Long memberId, int page, int size) {
+    public List<DirectChatRoomListResponse> findChatRoomList(Long memberId, int page, int size) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -143,7 +143,7 @@ public class DirectChatRoomService {
         // 채팅방별 정보 조회
         List<ChatRoomInfoDto> chatRoomInfoDtoList = chatMessageService.getChatRoomInfo(joinMemberChatRooms);
 
-        List<ChatRoomListResponse> chatRoomListResponseList = new ArrayList<>();
+        List<DirectChatRoomListResponse> directChatRoomListResponseList = new ArrayList<>();
 
         for (ChatRoomInfoDto chatRoomInfoDto : chatRoomInfoDtoList) {
             MemberChatRoom memberChatRoom = chatRoomInfoDto.getMemberChatRoom();
@@ -152,7 +152,7 @@ public class DirectChatRoomService {
                             memberChatRoom.getChatRoom(), memberChatRoom.getMember())
                     .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_CHAT_ROOM_NOT_FOUND));
 
-            ChatRoomListResponse chatRoomListResponse = ChatRoomListResponse.of(
+            DirectChatRoomListResponse directChatRoomListResponse = DirectChatRoomListResponse.of(
                     aesCipherUtil.encrypt(memberId),
                     aesCipherUtil.encrypt(chatRoomInfoDto.getMemberChatRoom().getChatRoom().getId()),
                     aesCipherUtil.encrypt(oppositeMemberChatRoom.getMember().getId()),
@@ -160,12 +160,12 @@ public class DirectChatRoomService {
                     chatRoomInfoDto
             );
 
-            chatRoomListResponseList.add(chatRoomListResponse);
+            directChatRoomListResponseList.add(directChatRoomListResponse);
         }
 
         chatNotificationService.startNotifications(memberId);
 
-        return chatRoomListResponseList;
+        return directChatRoomListResponseList;
     }
 
     /**

--- a/src/main/java/teamkiim/koffeechat/domain/chat/room/tech/controller/TechChatRoomApiDocument.java
+++ b/src/main/java/teamkiim/koffeechat/domain/chat/room/tech/controller/TechChatRoomApiDocument.java
@@ -11,8 +11,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import teamkiim.koffeechat.domain.chat.room.common.dto.response.ChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.tech.dto.response.EnterTechChatRoomResponse;
+import teamkiim.koffeechat.domain.chat.room.tech.dto.response.JoinTechChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.tech.dto.response.TechChatRoomListResponse;
 
 @Tag(name = "Tech(기술) 채팅방 API")
@@ -76,7 +76,7 @@ public @interface TechChatRoomApiDocument {
     @Operation(summary = "현재 참여중인 채팅방 목록 페이징 조회", description = "사용자가 현재 참여중인 채팅방의 목록을 페이징해 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원이 현재 속한 채팅방 정보 리스트를 반환한다.",
-                    content = @Content(schema = @Schema(implementation = ChatRoomListResponse.class))),
+                    content = @Content(schema = @Schema(implementation = JoinTechChatRoomListResponse.class))),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
                     examples = {@ExampleObject(name = "회원을 찾을 수 없는 경우")})),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",

--- a/src/main/java/teamkiim/koffeechat/domain/chat/room/tech/dto/response/JoinTechChatRoomListResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/chat/room/tech/dto/response/JoinTechChatRoomListResponse.java
@@ -1,0 +1,36 @@
+package teamkiim.koffeechat.domain.chat.room.tech.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamkiim.koffeechat.domain.chat.room.common.domain.ChatRoomType;
+import teamkiim.koffeechat.domain.chat.room.common.dto.ChatRoomInfoDto;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JoinTechChatRoomListResponse {
+
+    private String memberId;
+    private String chatRoomId;
+    private ChatRoomType chatRoomType;
+    private String chatRoomName;
+    private String lastMessageContent;
+    private LocalDateTime lastMessageTime;
+    private Long unreadMessageCount;
+
+    public static JoinTechChatRoomListResponse of(String memberId, String chatRoomId, ChatRoomInfoDto chatRoomInfo) {
+        return JoinTechChatRoomListResponse.builder()
+                .memberId(memberId)
+                .chatRoomId(chatRoomId)
+                .chatRoomType(chatRoomInfo.getMemberChatRoom().getChatRoom().getChatRoomType())
+                .chatRoomName(chatRoomInfo.getMemberChatRoom().getChatRoom().getName())
+                .lastMessageContent(chatRoomInfo.getLatestMessageContent())
+                .lastMessageTime(chatRoomInfo.getLatestMessageTime())
+                .unreadMessageCount(chatRoomInfo.getUnreadCount())
+                .build();
+    }
+}

--- a/src/main/java/teamkiim/koffeechat/domain/chat/room/tech/service/TechChatRoomService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/chat/room/tech/service/TechChatRoomService.java
@@ -18,12 +18,12 @@ import teamkiim.koffeechat.domain.chat.room.common.ChatRoomManager;
 import teamkiim.koffeechat.domain.chat.room.common.domain.ChatRoomType;
 import teamkiim.koffeechat.domain.chat.room.common.domain.MemberChatRoom;
 import teamkiim.koffeechat.domain.chat.room.common.dto.ChatRoomInfoDto;
-import teamkiim.koffeechat.domain.chat.room.common.dto.response.ChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.common.repository.MemberChatRoomRepository;
 import teamkiim.koffeechat.domain.chat.room.tech.domain.TechChatRoom;
 import teamkiim.koffeechat.domain.chat.room.tech.dto.request.CreateTechChatRoomServiceRequest;
 import teamkiim.koffeechat.domain.chat.room.tech.dto.response.CreateTechChatRoomResponse;
 import teamkiim.koffeechat.domain.chat.room.tech.dto.response.EnterTechChatRoomResponse;
+import teamkiim.koffeechat.domain.chat.room.tech.dto.response.JoinTechChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.tech.dto.response.TechChatRoomListResponse;
 import teamkiim.koffeechat.domain.chat.room.tech.repository.TechChatRoomRepository;
 import teamkiim.koffeechat.domain.member.domain.Member;
@@ -169,9 +169,9 @@ public class TechChatRoomService {
      * @param memberId 채팅방 목록 조회 요청한 회원 PK
      * @param page     페이징에 사용될 page
      * @param size     페이징에 사용될 size
-     * @return List<ChatRoomListResponse>
+     * @return List<JoinTechChatRoomListResponse>
      */
-    public List<ChatRoomListResponse> findJoinChatRoomList(Long memberId, int page, int size) {
+    public List<JoinTechChatRoomListResponse> findJoinChatRoomList(Long memberId, int page, int size) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -185,29 +185,21 @@ public class TechChatRoomService {
         // 채팅방별 정보 조회
         List<ChatRoomInfoDto> chatRoomInfoDtoList = chatMessageService.getChatRoomInfo(joinMemberChatRooms);
 
-        List<ChatRoomListResponse> chatRoomListResponseList = new ArrayList<>();
+        List<JoinTechChatRoomListResponse> joinTechChatRoomListResponseList = new ArrayList<>();
 
         for (ChatRoomInfoDto chatRoomInfoDto : chatRoomInfoDtoList) {
-            MemberChatRoom memberChatRoom = chatRoomInfoDto.getMemberChatRoom();
-
-            MemberChatRoom oppositeMemberChatRoom = memberChatRoomRepository.findByChatRoomExceptMember(
-                            memberChatRoom.getChatRoom(), memberChatRoom.getMember())
-                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_CHAT_ROOM_NOT_FOUND));
-
-            ChatRoomListResponse chatRoomListResponse = ChatRoomListResponse.of(
+            JoinTechChatRoomListResponse joinTechChatRoomListResponse = JoinTechChatRoomListResponse.of(
                     aesCipherUtil.encrypt(memberId),
                     aesCipherUtil.encrypt(chatRoomInfoDto.getMemberChatRoom().getChatRoom().getId()),
-                    aesCipherUtil.encrypt(oppositeMemberChatRoom.getMember().getId()),
-                    oppositeMemberChatRoom.getMember(),
                     chatRoomInfoDto
             );
 
-            chatRoomListResponseList.add(chatRoomListResponse);
+            joinTechChatRoomListResponseList.add(joinTechChatRoomListResponse);
         }
 
         chatNotificationService.startNotifications(memberId);
 
-        return chatRoomListResponseList;
+        return joinTechChatRoomListResponseList;
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 기술 채팅방 목록 조회 시, 상대방 회원이 조회 안되는 버그 수정 (기술 채팅방에서 상대방 회원 정보는 필요 없음)

## PR 유형
어떤 변경 사항이 있나요?

- 버그 수정
- 코드 리팩토링

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
