### PR TITLE
fix : 댓글 조회 시 댓글 작성 회원 ID가 잘못 삽입되는 버그 해결

### DIFF
--- a/src/main/java/teamkiim/koffeechat/domain/comment/service/CommentService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/comment/service/CommentService.java
@@ -112,7 +112,7 @@ public class CommentService {
                 .map(comment -> {
                     boolean isMemberWritten = comment.getMember().getId().equals(memberId);
                     return CommentInfoDto.of(aesCipherUtil.encrypt(comment.getId()), comment,
-                            aesCipherUtil.encrypt(memberId), isMemberWritten);
+                            aesCipherUtil.encrypt(comment.getMember().getId()), isMemberWritten);
                 }).toList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 게시글 상세 조회 / 댓글 조회 시, 댓글 작성한 회원의 Id가 조회한 회원의 id로 잘못 들어가는 버그 해결

- 버그 수정

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
