### PR TITLE
fix: 사용자 알림 목록으로 기술 게시글 알림을 null로 가져오는 문제 해결

### DIFF
--- a/src/main/java/teamkiim/koffeechat/domain/notification/service/NotificationService.java
+++ b/src/main/java/teamkiim/koffeechat/domain/notification/service/NotificationService.java
@@ -301,19 +301,23 @@ public class NotificationService {
                 : notificationRepository.findAllByReceiverAndNotificationType(receiver, notificationType, pageRequest)
                         .getContent();
 
-        return notificationList.stream().map(notification -> {
-            String encryptedId = aesCipherUtil.encrypt(notification.getId());
-            String encryptedSenderId =
-                    notification.getSender() != null ? aesCipherUtil.encrypt(notification.getSender().getId())
-                            : "KOFFEECHAT";
-            String encryptedUrlPK =
-                    notification.getUrlPK() != null ? aesCipherUtil.encrypt(notification.getUrlPK()) : null;
-            String encryptedCommentId =
-                    notification.getCommentId() != null ? aesCipherUtil.encrypt(notification.getCommentId()) : null;
+        return notificationList.stream()
+                .filter(notification -> !notification.getNotificationType().equals(NotificationType.TECH_POST))
+                .map(notification -> {
+                    String encryptedId = aesCipherUtil.encrypt(notification.getId());
+                    String encryptedSenderId =
+                            notification.getSender() != null ? aesCipherUtil.encrypt(notification.getSender().getId())
+                                    : "KOFFEECHAT";
+                    String encryptedUrlPK =
+                            notification.getUrlPK() != null ? aesCipherUtil.encrypt(notification.getUrlPK()) : null;
+                    String encryptedCommentId =
+                            notification.getCommentId() != null ? aesCipherUtil.encrypt(notification.getCommentId())
+                                    : null;
 
-            return NotificationListItemResponse.of(encryptedId, encryptedSenderId, encryptedUrlPK, encryptedCommentId,
-                    notification);
-        }).collect(Collectors.toList());
+                    return NotificationListItemResponse.of(encryptedId, encryptedSenderId, encryptedUrlPK,
+                            encryptedCommentId,
+                            notification);
+                }).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> 사용자 알림 목록으로 기술 게시글 알림을 null로 가져오는 문제 해결
알림 response 생성시 기술 게시글을 필터링해서 응답에 포함 안함

## PR 유형
어떤 변경 사항이 있나요?

- 버그 수정

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
