### PR TITLE
fix: 기술 게시글 알림 저장 로직 삭제

### DIFF
--- a/src/main/java/teamkiim/koffeechat/domain/notification/dto/response/SkillPostNotificationResponse.java
+++ b/src/main/java/teamkiim/koffeechat/domain/notification/dto/response/SkillPostNotificationResponse.java
@@ -1,11 +1,11 @@
 package teamkiim.koffeechat.domain.notification.dto.response;
 
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import teamkiim.koffeechat.domain.notification.domain.Notification;
 import teamkiim.koffeechat.domain.notification.domain.NotificationType;
+import teamkiim.koffeechat.domain.post.common.domain.Post;
 import teamkiim.koffeechat.domain.post.common.domain.PostCategory;
+import teamkiim.koffeechat.domain.post.dev.domain.ChildSkillCategory;
 
 @Getter
 @Builder
@@ -13,30 +13,22 @@ public class SkillPostNotificationResponse {
 
     private String receiverId;  //알림을 받는 회원
 
-    private long unreadNotificationCount;  //읽지 않은 알림 갯수
-
     private String title;
 
     private String url;
 
     private PostCategory postCategory;
 
-    private boolean isRead;
-
     private NotificationType notificationType;
 
-    private LocalDateTime createdTime;
-
-    public static SkillPostNotificationResponse of(String receiverId, String postId, Notification notification) {
+    public static SkillPostNotificationResponse of(ChildSkillCategory childSkillCategory, String receiverId,
+                                                   String postId, Post post) {
         return SkillPostNotificationResponse.builder()
                 .receiverId(receiverId)
-                .unreadNotificationCount(notification.getReceiver().getUnreadNotificationCount())
-                .title(notification.getTitle())  //기술 이름
+                .title(childSkillCategory.toString())  //기술 이름
                 .url(postId)
-                .postCategory(notification.getPostType())
-                .isRead(false)
-                .notificationType(notification.getNotificationType())
-                .createdTime(notification.getCreatedTime())
+                .postCategory(post.getPostCategory())
+                .notificationType(NotificationType.TECH_POST)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

>기술 게시글 알림 저장 로직 삭제, 기술 알림이 POST, TECH_POST로 두 개 저장돼서 TECH_POST를 삭제함

## PR 유형
어떤 변경 사항이 있나요?

- 새로운 기능 추가

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
